### PR TITLE
ISecureRandom: use generate directly

### DIFF
--- a/controller/userscontroller.php
+++ b/controller/userscontroller.php
@@ -130,7 +130,7 @@ class UsersController extends Controller {
 			$user->setDisplayName($displayName);
 		}
 
-		$token = $this->secureRandom->getMediumStrengthGenerator()->generate(
+		$token = $this->secureRandom->generate(
 			21,
 			ISecureRandom::CHAR_DIGITS .
 			ISecureRandom::CHAR_LOWER .


### PR DESCRIPTION
getMediumStrengthGenerator is deprecated and will be removed in NC16
https://github.com/nextcloud/server/pull/12907