### PR TITLE
Fix default share permissions

### DIFF
--- a/src/GuestForm.vue
+++ b/src/GuestForm.vue
@@ -146,7 +146,6 @@
 				const attributes = {
 					shareType: 0,
 					shareWith: this.guest.username,
-					permissions: OC.PERMISSION_CREATE | OC.PERMISSION_UPDATE | OC.PERMISSION_READ | OC.PERMISSION_DELETE,
 					path: this.model.fileInfoModel.getFullPath()
 				};
 


### PR DESCRIPTION
Fix #114 

Handled by default in core https://github.com/nextcloud/server/blob/52f24b50f5dbcaa8e3e022b44bd070bca336fcf8/apps/files_sharing/lib/Controller/ShareAPIController.php#L393
