### PR TITLE
always allow impersonate, so the logout handler is registered

### DIFF
--- a/lib/AppWhitelist.php
+++ b/lib/AppWhitelist.php
@@ -48,7 +48,7 @@ class AppWhitelist {
 	/** @var int */
 	private $baseUrlLength;
 
-	const WHITELIST_ALWAYS = ',core,theming,settings,avatar,files,heartbeat,dav,guests';
+	const WHITELIST_ALWAYS = ',core,theming,settings,avatar,files,heartbeat,dav,guests,impersonate';
 
 	const DEFAULT_WHITELIST = 'files_trashbin,files_versions,files_sharing,files_texteditor,activity,firstrunwizard,gallery,notifications';
 


### PR DESCRIPTION
fixes #142

the impersonate app is required to register the logout handler. Otherwise, you're stuck with the logged in user, as described in the bug report. I decided to add it to the permanent whitelist, to avoid confusion with the ability to impersonate – there is a different settings for that, based in groups.