### PR TITLE
Pass a proper callable

### DIFF
--- a/lib/Storage/DirMask.php
+++ b/lib/Storage/DirMask.php
@@ -195,6 +195,8 @@ class DirMask extends PermissionsMask {
 			$storage = $this;
 		}
 		$sourceCache = $this->storage->getCache($path, $storage);
-		return new DirMaskCache($sourceCache, $this->mask, [$this, 'checkPath']);
+		return new DirMaskCache($sourceCache, $this->mask, function(string $path) {
+			return $this->checkPath($path);
+		});
 	}
 }


### PR DESCRIPTION
Just passing the class and the function doesn't help if we try to call
it from another class (the wrapper) since the function itself is
protected.

This wraps around that properly.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>