### PR TITLE
Use the event dispatcher interface

### DIFF
--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -23,18 +23,16 @@ declare(strict_types=1);
 namespace OCA\Guests;
 
 use OC\Cache\CappedMemoryCache;
-use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Security\IHasher;
 use OCP\User\Backend\ABackend;
 use OCP\User\Backend\ICheckPasswordBackend;
 use OCP\User\Backend\ICountUsersBackend;
-use OCP\User\Backend\ICreateUserBackend;
 use OCP\User\Backend\IGetDisplayNameBackend;
 use OCP\User\Backend\IGetHomeBackend;
 use OCP\User\Backend\ISetDisplayNameBackend;
 use OCP\User\Backend\ISetPasswordBackend;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -56,7 +54,7 @@ class UserBackend extends ABackend
 	private $allowListing = true;
 
 	public function __construct(
-		EventDispatcher $eventDispatcher,
+		EventDispatcherInterface $eventDispatcher,
 		IDBConnection $connection,
 		Config $config,
 		IHasher $hasher

--- a/tests/unit/UserBackendTest.php
+++ b/tests/unit/UserBackendTest.php
@@ -24,14 +24,15 @@ namespace OCA\Guests\Test\Unit;
 
 use OCA\Guests\Config;
 use OCA\Guests\UserBackend;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 
 /**
  * @group DB
  */
 class UserBackendTest extends TestCase {
-	/** @var Config|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var Config|MockObject */
 	private $config;
 
 	/** @var UserBackend */
@@ -51,7 +52,7 @@ class UserBackendTest extends TestCase {
 		$this->config = $this->createMock(Config::class);
 
 		$this->backend = new UserBackend(
-			$this->createMock(EventDispatcher::class),
+			$this->createMock(EventDispatcherInterface::class),
 			\OC::$server->getDatabaseConnection(),
 			$this->config,
 			\OC::$server->getHasher()


### PR DESCRIPTION
Then we can fix the parameter order (server PR pending) there (event and
name have switched position).

Otherwise the logs on 18 are full of warnings.