### PR TITLE
On firstlogin filetransfer

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ Guests users can only access files shared to them and can't create any files out
 	<screenshot>https://raw.githubusercontent.com/nextcloud/guests/master/screenshots/settings.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/guests/master/screenshots/dropdown.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="18" max-version="18" />
+		<nextcloud min-version="18" max-version="19" />
 	</dependencies>
 	<commands>
 		<command>OCA\Guests\Command\ListCommand</command>

--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -242,7 +242,10 @@ class Hooks {
 			$ownershipTransferService->transfer(
 				$guestUser,
 				$user,
-				'/'
+				'/',
+				null,
+				true,
+				true
 			);
 		} catch (TransferOwnershipException $e) {
 			$this->logger->logException($e, [


### PR DESCRIPTION
Move the files of the guest user to the root of the target user when
this is enabled on firstlogin. This avoids a separate folder that the
users have to enter.

Test together with: https://github.com/nextcloud/server/pull/19233