### PR TITLE
If files could not be transfered, the guest user should still be migrated

### DIFF
--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -252,7 +252,6 @@ class Hooks {
 				'level' => ILogger::ERROR,
 				'message' => 'Could not import guest user data',
 			]);
-			return;
 		}
 
 		// Update incomming shares


### PR DESCRIPTION
1. User gets invited as a guest.
2. User logs in via SAML, having the same email address assigned with their account as an existing guest account

This PR makes sure that even though the guest user has never logged in (and therefore the home storage is not setup yet so the file migration fails) the guest account will still be migrated to a regular saml account.