### PR TITLE
rephrased some guest invitation strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ guestForm.$mount('#guest-root')
 // entry in the sharing input search results
 const result = {
 	icon: 'icon-guests',
-	displayName: t('guests', 'Create guest account'),
+	displayName: t('guests', 'Invite guest'),
 	handler: async self => {
 		return guestForm.populate(self.fileInfo, self.query)
 	},

--- a/src/views/GuestForm.vue
+++ b/src/views/GuestForm.vue
@@ -56,7 +56,7 @@
 						:class="{ 'icon-loading-small': loading }"
 						class="primary button-save"
 						:disabled="loading">
-						{{ t('guests', 'Save and create share') }}
+						{{ t('guests', 'Invite user and create share') }}
 					</button>
 				</div>
 			</form>
@@ -110,7 +110,7 @@ export default {
 
 	computed: {
 		formatTitle() {
-			return t('guests', 'Create guest account for {name}', {
+			return t('guests', 'Invite {name}', {
 				name: this.guest.fullName
 					? this.guest.fullName
 					: this.guest.email,


### PR DESCRIPTION
"Create guest account" is a quite technical term that may discourage lower-level users from hitting that button.
Talking about "Inviting" instead fits the actual act better.

Signed-off-by: Sascha Wiswedel <sascha.wiswedel@nextcloud.com>