### PR TITLE
Delay call to canCreateGuests when checking for loaded scripts

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -104,14 +104,13 @@ class Application extends App {
 		$userSession = $server->getUserSession();
 		$user = $userSession->getUser();
 
-		if (!$this->getGuestManager()->isGuest($user) && $this->getConfig()->canCreateGuests()) {
-			$server->getEventDispatcher()->addListener(
-				'OCA\Files::loadAdditionalScripts',
-				function () {
-					\OCP\Util::addScript(self::APP_ID, 'main');
+		$server->getEventDispatcher()->addListener(
+			'OCA\Files::loadAdditionalScripts', function () use ($user) {
+				if (!$this->getGuestManager()->isGuest($user) && $this->getConfig()->canCreateGuests()) {
+					\OCP\Util::addScript('guests', 'main');
 				}
-			);
-		}
+			}
+		);
 
 		$server->getGroupManager()->addBackend($container->query(GroupBackend::class));
 		/** @var Hooks $hooks */


### PR DESCRIPTION
For some reason the getUser call in https://github.com/nextcloud/guests/blob/eb5c122d4c052bbfd11b677fd7e34da837099184/lib/Config.php#L116 does not return a valid user when called to early for SAML users. Moving the check into the event listener fixes the issue, although I have no idea why the previous one worked for internal users but not for SAML ones.