### PR TITLE
Check individual users for getgroups and ingroup

### DIFF
--- a/lib/GroupBackend.php
+++ b/lib/GroupBackend.php
@@ -76,8 +76,7 @@ class GroupBackend extends ABackend implements ICountUsersBackend, IGroupDetails
 	 * Checks whether the user is member of a group or not.
 	 */
 	public function inGroup($uid, $gid) {
-		return $gid === $this->groupName && in_array($uid, $this->getMembers());
-
+		return $gid === $this->groupName && $this->guestManager->isGuest($uid);
 	}
 
 	/**
@@ -91,7 +90,7 @@ class GroupBackend extends ABackend implements ICountUsersBackend, IGroupDetails
 	 * if the user exists at all.
 	 */
 	public function getUserGroups($uid) {
-		if (in_array($uid, $this->getMembers())) {
+		if ($this->guestManager->isGuest($uid)) {
 			return [$this->groupName];
 		}
 


### PR DESCRIPTION
The getMembers functional (while already a tad batter) is querying the
whole guest table. Which is overkill. And also not needed. Esp since in
most cases we only need this info for the current user etc.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>