### PR TITLE
Only show whitelisted apps

### DIFF
--- a/lib/RestrictionManager.php
+++ b/lib/RestrictionManager.php
@@ -26,6 +26,7 @@ use OC\NavigationManager;
 use OCA\Files_External\Config\ExternalMountPoint;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\Mount\IMountPoint;
+use OCP\INavigationManager;
 use OCP\IRequest;
 use OCP\IServerContainer;
 use OCP\IUser;
@@ -96,7 +97,7 @@ class RestrictionManager {
 			/** @var NavigationManager $navManager */
 			$navManager = $this->server->getNavigationManager();
 
-			$this->server->registerService('NavigationManager', function () use ($navManager) {
+			$this->server->registerService(INavigationManager::class, function () use ($navManager) {
 				return new FilteredNavigationManager($this->userSession->getUser(), $navManager, $this->whitelist);
 			});
 		}


### PR DESCRIPTION
**Before**

![Screenshot from 2020-09-11 01-41-13](https://user-images.githubusercontent.com/3902676/92825735-2c49c280-f3d0-11ea-89f2-e3c5bbd796ce.png)

**After**

![Screenshot from 2020-09-11 01-41-33](https://user-images.githubusercontent.com/3902676/92825764-3370d080-f3d0-11ea-95f9-4fb860bbe7ea.png)

It seems that registerService($alias) does not work. As the navigation manager is registered with INavigationManager since Nextcloud 19 the FilteredNavigationManager is not used. 