### PR TITLE
Add coverage to fix CI failure

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -252,10 +252,6 @@ jobs:
         with:
           path: apps/${{ env.APP_NAME }}
 
-      - name: Set up PHPUnit
-        working-directory: apps/${{ env.APP_NAME }}
-        run: composer i
-
       - name: Set up php ${{ matrix.php-versions }}
         uses: "shivammathur/setup-php@v2"
         with:
@@ -263,6 +259,10 @@ jobs:
           extensions: mbstring, iconv, fileinfo, intl, oci8
           tools: phpunit:8.5.2
           coverage: none
+
+      - name: Set up PHPUnit
+        working-directory: apps/${{ env.APP_NAME }}
+        run: composer i
 
       - name: Set up Nextcloud
         run: |

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -49,6 +49,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           tools: phpunit
           extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite
+          coverage: none
 
       - name: Set up PHPUnit
         working-directory: apps/${{ env.APP_NAME }}


### PR DESCRIPTION
Should fix this newly appeared issue: https://github.com/nextcloud/guests/pull/510/checks?check_run_id=1557739738

> Code coverage needs to be enabled in php.ini by setting 'xdebug.mode' to 'coverage'

The change is taken from the mail app.