### PR TITLE
fix inconsistent persistence of guest user properties

### DIFF
--- a/lib/GuestManager.php
+++ b/lib/GuestManager.php
@@ -113,11 +113,11 @@ class GuestManager {
 			$this->userBackend
 		);
 
-		$this->config->setUserValue($userId, 'settings', 'email', $email);
+		$user->setEMailAddress($email);
 		$this->config->setUserValue($userId, 'guests', 'created_by', $createdBy->getUID());
 
 		if ($displayName) {
-			$this->userBackend->setDisplayName($userId, $displayName);
+			$user->setDisplayName($displayName);
 		}
 
 		if ($language) {
@@ -145,7 +145,7 @@ class GuestManager {
 			);
 		}
 
-		$this->config->setUserValue($userId, 'files', 'quota', '0 B');
+		$user->setQuota('0 B');
 
 		return $user;
 	}

--- a/tests/unit/GuestManagerTest.php
+++ b/tests/unit/GuestManagerTest.php
@@ -171,9 +171,17 @@ class GuestManagerTest extends TestCase {
 			->with('guest@example.com', str_repeat('4', 20), $this->userBackend)
 			->willReturn($guestUser);
 
-		$this->userBackend->expects($this->once())
+		$guestUser->expects($this->once())
 			->method('setDisplayName')
-			->with('guest@example.com', 'Example Guest');
+			->with('Example Guest');
+		$guestUser->method('setEMailAddress')
+			->willReturnCallback(function ($email) {
+				$this->config->setUserValue('guest@example.com', 'settings', 'email', $email);
+			});
+		$guestUser->method('setQuota')
+			->willReturnCallback(function ($quota) {
+				$this->config->setUserValue('guest@example.com', 'files', 'quota', $quota);
+			});
 
 		$returnedUser = $this->guestManager->createGuest(
 			$createdByUser,


### PR DESCRIPTION
Fixes #548 - fixes an inconsistency of display name and email address on guest user creation

Signed-off-by: Markus Hoffrogge <mhoffrogge@gmail.com>