### PR TITLE
Compare mask root with storage permissions

### DIFF
--- a/tests/unit/Storage/DirMaskTest.php
+++ b/tests/unit/Storage/DirMaskTest.php
@@ -40,7 +40,7 @@ class DirMaskTest extends TestCase {
 			'mask' => Constants::PERMISSION_READ,
 		]);
 
-		$this->assertEquals(Constants::PERMISSION_ALL - Constants::PERMISSION_DELETE, $mask->getPermissions(''));
+		$this->assertEquals($storage->getPermissions(''), $mask->getPermissions(''));
 		$this->assertEquals(Constants::PERMISSION_READ, $mask->getPermissions('readonly'));
 
 		$this->assertFalse($mask->isCreatable('readonly'));


### PR DESCRIPTION
Tests were failing due to https://github.com/nextcloud/server/commit/ed2d02d5f1000c76776c6e8dbe24fa787ffe6d0d#diff-41ddf4bd5d702aadb83085d83bfd27471eecdcffdff2ce5957a3bf80788511f3R156

I'm not fully sure if the server change may have any unexpected side effects if the root of a storage is now always deletable if it can be updated, however for the DirMask test it would make sense from my perspective to compare the root permissions with the ones from the storage in use.

@icewind1991 Maybe you can check that again.

Fix #640