### PR TITLE
Don't ask the database for user ids which are not emails

### DIFF
--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -244,12 +244,16 @@ class UserBackend extends ABackend implements
 	 *
 	 * @param string $uid The username
 	 * @param string $password The password
-	 * @return string
+	 * @return string|bool
 	 *
 	 * Check if the password is correct without logging in the user
 	 * returns the user id or false
 	 */
 	public function checkPassword(string $uid, string $password) {
+		if (strpos($uid, '@') === false) {
+			return false;
+		}
+
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->select('uid', 'password')
 			->from('guests_users')
@@ -284,6 +288,10 @@ class UserBackend extends ABackend implements
 	 */
 	private function loadUser($uid) {
 		$uid = (string)$uid;
+		if (strpos($uid, '@') === false) {
+			return false;
+		}
+
 		if (!isset($this->cache[$uid])) {
 			//guests $uid could be NULL or ''
 			if ($uid === '') {
@@ -404,6 +412,10 @@ class UserBackend extends ABackend implements
 	}
 
 	public function getRealUID(string $uid): string {
+		if (strpos($uid, '@') === false) {
+			throw new \RuntimeException($uid . ' does not exist');
+		}
+
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->select('uid')
 			->from('guests_users')

--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -416,22 +416,14 @@ class UserBackend extends ABackend implements
 			throw new \RuntimeException($uid . ' does not exist');
 		}
 
-		$qb = $this->dbConn->getQueryBuilder();
-		$qb->select('uid')
-			->from('guests_users')
-			->where(
-				$qb->expr()->eq(
-					'uid_lower', $qb->createNamedParameter(mb_strtolower($uid))
-				)
-			);
-		$result = $qb->execute();
-		$row = $result->fetch();
-		$result->closeCursor();
+		if (!isset($this->cache[$uid]['uid'])) {
+			$this->loadUser($uid);
+		}
 
-		if (!$row) {
+		if (!isset($this->cache[$uid]['uid'])) {
 			throw new \RuntimeException($uid . ' does not exist');
 		}
 
-		return $row['uid'];
+		return $this->cache[$uid]['uid'];
 	}
 }

--- a/tests/unit/UserBackendTest.php
+++ b/tests/unit/UserBackendTest.php
@@ -67,17 +67,17 @@ class UserBackendTest extends TestCase {
 	}
 
 	public function testCreate() {
-		$this->backend->createUser('foo', 'bar');
-		$this->assertTrue($this->backend->userExists('foo'));
+		$this->backend->createUser('foo@example.tld', 'bar');
+		$this->assertTrue($this->backend->userExists('foo@example.tld'));
 
-		$this->assertEquals(['foo'], $this->backend->getUsers());
+		$this->assertEquals(['foo@example.tld'], $this->backend->getUsers());
 	}
 
 	public function testNoListing() {
-		$this->backend->createUser('foo', 'bar');
-		$this->assertTrue($this->backend->userExists('foo'));
+		$this->backend->createUser('foo@example.tld', 'bar');
+		$this->assertTrue($this->backend->userExists('foo@example.tld'));
 
-		$this->assertEquals(['foo'], $this->backend->getUsers());
+		$this->assertEquals(['foo@example.tld'], $this->backend->getUsers());
 
 		$this->backend->setAllowListing(false);
 


### PR DESCRIPTION
User ids in the guest app are always emails, so there is no
use in querying the database when there is no @ in the user id.

Commit 1 saves 18.061 queries from our famous query log
Commit 2 saves 17.898 queries from our famous query log