### PR TITLE
Add option to delete old guest accounts during auto-conversion

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -87,7 +87,7 @@ jobs:
 
     services:
       mysql:
-        image: mariadb
+        image: mariadb:10.5
         ports:
           - 4444:3306/tcp
         env:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Guest users who eventually turn into full users (provided by any other user back
 1. Nextcloud 18 or higher
 2. target user needs to have the same email address as the guest user
 3. config.php setting `'migrate_guest_user_data' => true,`
+4. config.php setting `'remove_guest_account_on_conversion' => true` if you want the old account to also be deleted. By default the old account will just be disabled.
 
 ## Available occ commands
 

--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -260,8 +260,13 @@ class Hooks {
 			$this->shareManager->updateShare($share);
 		}
 
-		// Disable previous account
-		$guestUser->setEnabled(false);
+		if ($this->config->getSystemValue('remove_guest_account_on_conversion', false) === false) {
+			// Disable previous account
+			$guestUser->setEnabled(false);
+		} else {
+			// Remove previous account
+			$guestUser->delete();
+		}
 
 		$notification = $this->notificationManager->createNotification();
 		$notification


### PR DESCRIPTION
This is disabled by default and can be enabled with
`'remove_guest_account_on_conversion' => true`

Closes #610

Signed-off-by: Carl Schwan <carl@carlschwan.eu>