### PR TITLE
Force-load theme at the right moment

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -54,6 +54,7 @@ class Application extends App implements IBootstrap {
 		$container = $this->getContainer();
 		$server = $container->getServer();
 		$server->getUserManager()->registerBackend($container->query(UserBackend::class));
+		\OC_App::loadApp('theming');
 		$server->getGroupManager()->addBackend($container->query(GroupBackend::class));
 	}
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/guests/issues/719

It seems that the group manager is implicitly triggering the loading
routine for the theme namespace, but that one is not available yet at
this stage.

The fix is to force load the theme app so that the namespace is
available early enough when needed.

This fixes an issue where the theme was not appearing for guest users.


Tests:
- [x] theme works
- [x] when theme app is disabled, it is also correctly disabled as guest (so `loadApp()` doesn't load if disabled)
