### PR TITLE
Add return value when successfully creating a user through occ

### DIFF
--- a/lib/Command/AddCommand.php
+++ b/lib/Command/AddCommand.php
@@ -153,6 +153,7 @@ class AddCommand extends Command {
 
 		if ($user instanceof IUser) {
 			$output->writeln('<info>The guest account user "' . $user->getUID() . '" was created successfully</info>');
+			return 0;
 		} else {
 			$output->writeln('<error>An error occurred while creating the user</error>');
 			return 1;

--- a/lib/Command/ListCommand.php
+++ b/lib/Command/ListCommand.php
@@ -54,7 +54,7 @@ class ListCommand extends Base {
 			} else {
 				$output->writeln("<info>No guests created</info>");
 			}
-			return;
+			return 0;
 		}
 
 		if ($outputType === self::OUTPUT_FORMAT_JSON || $outputType === self::OUTPUT_FORMAT_JSON_PRETTY) {
@@ -65,5 +65,6 @@ class ListCommand extends Base {
 			$table->setRows($guests);
 			$table->render();
 		}
+		return 0;
 	}
 }


### PR DESCRIPTION
Avoid throwing an error when creating a guest user:

```
An unhandled exception has been thrown:
TypeError: Return value of "OCA\Guests\Command\AddCommand::execute()" must be of the type int, "null" returned. in /var/www/html/apps-extra/deck/vendor/symfony/console/Command/Command.php:302
Stack trace:
#0 /var/www/html/apps-extra/deck/vendor/symfony/console/Application.php(978): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#1 /var/www/html/apps-extra/deck/vendor/symfony/console/Application.php(295): Symfony\Component\Console\Application->doRunCommand(Object(OCA\Guests\Command\AddCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#2 /var/www/html/apps-extra/deck/vendor/symfony/console/Application.php(167): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#3 /var/www/html/lib/private/Console/Application.php(211): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#4 /var/www/html/console.php(99): OC\Console\Application->run()
#5 /var/www/html/occ(11): require_once('/var/www/html/c...')
#6 {main}%                       
```