### PR TITLE
Add capabilities

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -23,6 +23,7 @@ namespace OCA\Guests\AppInfo;
 
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Guests\Listener\LoadAdditionalScriptsListener;
+use OCA\Guests\Capabilities;
 use OCA\Guests\GroupBackend;
 use OCA\Guests\Hooks;
 use OCA\Guests\Listener\ShareAutoAcceptListener;
@@ -49,6 +50,8 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function register(IRegistrationContext $context): void {
+		$context->registerCapability(Capabilities::class);
+
 		$context->registerEventListener(LoadAdditionalScriptsEvent::class, LoadAdditionalScriptsListener::class);
 		$context->registerEventListener(ShareCreatedEvent::class, ShareAutoAcceptListener::class);
 		$context->registerEventListener(BeforeTemplateRenderedEvent::class, TalkIntegrationListener::class);

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @copyright Copyright (c) 2022 Marcel Müller <marcel-mueller@gmx.de>
+ *
+ * @author Marcel Müller <marcel-mueller@gmx.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Guests;
+
+use OCP\Capabilities\ICapability;
+
+/**
+ * Class Capabilities
+ *
+ * @package OCA\Guests
+ */
+class Capabilities implements ICapability {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getCapabilities() {
+		return [
+			'guests' => [
+				'enabled' => true,
+			],
+		];
+	}
+}

--- a/tests/unit/CapabilitiesTest.php
+++ b/tests/unit/CapabilitiesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Marcel Müller <marcel-mueller@gmx.de>
+ *
+ * @author Marcel Müller <marcel-mueller@gmx.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Guests\Tests;
+
+use OCA\Guests\Capabilities;
+use Test\TestCase;
+
+class CapabilitiesTest extends TestCase {
+	public function testCapabilities(): void {
+		$capabilities = new Capabilities();
+
+		$this->assertEquals([
+			'guests' => [
+				'enabled' => true,
+			]
+		], $capabilities->getCapabilities());
+	}
+}


### PR DESCRIPTION
Add capabilities to guest app, so the availability of the guest app can be checked by clients (Talk iOS for example).

Ref: https://github.com/nextcloud/spreed/issues/7488