### PR TITLE
Limit settings to whitelisted apps

### DIFF
--- a/lib/AppWhitelist.php
+++ b/lib/AppWhitelist.php
@@ -80,7 +80,7 @@ class AppWhitelist {
 		$this->logger = $logger;
 	}
 
-	private function isAppWhitelisted($appId) {
+	public function isAppWhitelisted($appId) {
 		$whitelist = $this->config->getAppWhitelist();
 		$alwaysEnabled = explode(',', self::WHITELIST_ALWAYS);
 

--- a/lib/FilteredSettingsManager.php
+++ b/lib/FilteredSettingsManager.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace OCA\Guests;
+
+use OCP\IUser;
+use OCP\Settings\IManager;
+
+class FilteredSettingsManager implements IManager {
+
+	/** @var IManager */
+	private $manager;
+	/** @var AppWhitelist */
+	private $appWhitelist;
+
+	public function __construct(IManager $manager, AppWhitelist $appWhitelist) {
+		$this->manager = $manager;
+		$this->appWhitelist = $appWhitelist;
+	}
+
+	private function isSettingAllowed(string $setting): bool {
+		$appId = \OC\AppFramework\App::getAppIdForClass($setting);
+		return $this->appWhitelist->isAppWhitelisted($appId);
+	}
+
+	public function registerSection(string $type, string $section) {
+		$this->manager->registerSection($type, $section);
+	}
+
+	public function registerSetting(string $type, string $setting) {
+		if (!$this->isSettingAllowed($setting)) {
+			return;
+		}
+
+		$this->manager->registerSetting($type, $setting);
+	}
+
+	public function getAdminSections(): array {
+		return $this->manager->getAdminSections();
+	}
+
+	public function getPersonalSections(): array {
+		return $this->manager->getPersonalSections();
+	}
+
+	public function getAdminSettings($section, bool $subAdminOnly = false): array {
+		return $this->manager->getAdminSettings($section, $subAdminOnly);
+	}
+
+	public function getAllowedAdminSettings(string $section, IUser $user): array {
+		return $this->manager->getAllowedAdminSettings($section, $user);
+	}
+
+	public function getAllAllowedAdminSettings(IUser $user): array {
+		return $this->manager->getAllAllowedAdminSettings($user);
+	}
+
+	public function getPersonalSettings($section): array {
+		return $this->manager->getPersonalSettings($section);
+	}
+}

--- a/lib/RestrictionManager.php
+++ b/lib/RestrictionManager.php
@@ -32,6 +32,7 @@ use OCP\IRequest;
 use OCP\IServerContainer;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\Settings\IManager;
 
 class RestrictionManager {
 	/** @var AppWhitelist */
@@ -100,6 +101,11 @@ class RestrictionManager {
 
 			$this->server->registerService(INavigationManager::class, function () use ($navManager) {
 				return new FilteredNavigationManager($this->userSession->getUser(), $navManager, $this->whitelist);
+			});
+
+			$settingsManager = $this->server->get(IManager::class);
+			$this->server->registerService(IManager::class, function () use ($settingsManager) {
+				return new FilteredSettingsManager($this->userSession->getUser(), $settingsManager, $this->whitelist);
 			});
 		}
 	}


### PR DESCRIPTION
Ensure that we only register settings settings for guest users where the namespace is actually coming from one of the whitelisted apps.

Fixes https://github.com/nextcloud/server/issues/20461