### PR TITLE
register user backends in `boot` instead of `register`

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -37,8 +37,10 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\AppFramework\IAppContainer;
+use OCP\IGroupManager;
 use OCP\IServerContainer;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Share\Events\ShareCreatedEvent;
 
@@ -55,16 +57,14 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(LoadAdditionalScriptsEvent::class, LoadAdditionalScriptsListener::class);
 		$context->registerEventListener(ShareCreatedEvent::class, ShareAutoAcceptListener::class);
 		$context->registerEventListener(BeforeTemplateRenderedEvent::class, TalkIntegrationListener::class);
-
-		// need to cheat here since there's no way to register these in IRegistrationContext
-		$container = $this->getContainer();
-		$server = $container->getServer();
-		$server->getUserManager()->registerBackend($container->query(UserBackend::class));
-		\OC_App::loadApp('theming');
-		$server->getGroupManager()->addBackend($container->query(GroupBackend::class));
 	}
 
 	public function boot(IBootContext $context): void {
+		// need to cheat here since there's no way to register these in IRegistrationContext
+		$container = $context->getServerContainer();
+		$container->get(IUserManager::class)->registerBackend($container->query(UserBackend::class));
+		$container->get(IGroupManager::class)->addBackend($container->query(GroupBackend::class));
+
 		$this->setupGuestManagement($context->getAppContainer(), $context->getServerContainer());
 		$this->setupGuestRestrictions($context->getAppContainer(), $context->getServerContainer());
 		$this->setupNotifications($context->getAppContainer());

--- a/lib/GroupBackend.php
+++ b/lib/GroupBackend.php
@@ -111,7 +111,7 @@ class GroupBackend extends ABackend implements ICountUsersBackend, IGroupDetails
 	 * Returns a list with all groups
 	 */
 	public function getGroups($search = '', $limit = -1, $offset = 0): array {
-		return $offset === 0 ? [$this->groupName] : [];
+		return $offset == 0 ? [$this->groupName] : [];
 	}
 
 	/**

--- a/lib/Storage/DirMask.php
+++ b/lib/Storage/DirMask.php
@@ -100,41 +100,41 @@ class DirMask extends PermissionsMask {
 		}
 	}
 
-	public function rename($path1, $path2): bool {
-		if (!$this->isUpdatable($path1)) {
+	public function rename($source, $target): bool {
+		if (!$this->isUpdatable($source)) {
 			return false;
 		}
-		if ($this->file_exists($path2)) {
-			if ($this->isUpdatable($path2)) {
-				return $this->storage->rename($path1, $path2);
+		if ($this->file_exists($target)) {
+			if ($this->isUpdatable($target)) {
+				return $this->storage->rename($source, $target);
 			}
 		} else {
-			$parent = dirname($path2);
+			$parent = dirname($target);
 			if ($parent === '.') {
 				$parent = '';
 			}
 			if ($this->isCreatable($parent)) {
-				return $this->storage->rename($path1, $path2);
+				return $this->storage->rename($source, $target);
 			}
 		}
 		return false;
 	}
 
-	public function copy($path1, $path2): bool {
-		if (!$this->isReadable($path1)) {
+	public function copy($source, $target): bool {
+		if (!$this->isReadable($source)) {
 			return false;
 		}
-		if ($this->file_exists($path2)) {
-			if ($this->isUpdatable($path2)) {
-				return $this->storage->copy($path1, $path2);
+		if ($this->file_exists($target)) {
+			if ($this->isUpdatable($target)) {
+				return $this->storage->copy($source, $target);
 			}
 		} else {
-			$parent = dirname($path2);
+			$parent = dirname($target);
 			if ($parent === '.') {
 				$parent = '';
 			}
 			if ($this->isCreatable($parent)) {
-				return $this->storage->copy($path1, $path2);
+				return $this->storage->copy($source, $target);
 			}
 		}
 		return false;

--- a/lib/Storage/DirMask.php
+++ b/lib/Storage/DirMask.php
@@ -100,6 +100,9 @@ class DirMask extends PermissionsMask {
 		}
 	}
 
+	/**
+	 * @psalm-suppress ParamNameMismatch
+	 */
 	public function rename($source, $target): bool {
 		if (!$this->isUpdatable($source)) {
 			return false;
@@ -119,7 +122,10 @@ class DirMask extends PermissionsMask {
 		}
 		return false;
 	}
-
+	
+	/**
+	 * @psalm-suppress ParamNameMismatch
+	 */
 	public function copy($source, $target): bool {
 		if (!$this->isReadable($source)) {
 			return false;

--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -247,7 +247,7 @@ class UserBackend extends ABackend implements
 	/**
 	 * Check if the password is correct
 	 *
-	 * @return string|bool
+	 * @return string|false
 	 *
 	 * Check if the password is correct without logging in the user
 	 * returns the user id or false
@@ -377,7 +377,7 @@ class UserBackend extends ABackend implements
 	/**
 	 * counts the users in the database
 	 *
-	 * @return int|bool
+	 * @return int|false
 	 */
 	public function countUsers() {
 		$query = $this->dbConn->getQueryBuilder();


### PR DESCRIPTION
this should prevent #719 without having to force-load the theming app.

Also includes a small fix that was preventing the guest group from being returned from group search