### PR TITLE
fix migrate guest user being triggered on mixed case email

### DIFF
--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -221,7 +221,7 @@ class Hooks {
 			return;
 		}
 
-		if ($email === $user->getUID()) {
+		if (strtolower($email) === strtolower($user->getUID())) {
 			// This is the guest user, logging in for the very first time
 			return;
 		}


### PR DESCRIPTION
Make the logic that prevents a guest from being migrated to itself from triggering when an email contains upper case.