### PR TITLE
Include shareType in share select option data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@nextcloud/dialogs": "^4.0.1",
         "@nextcloud/event-bus": "^3.1.0",
         "@nextcloud/router": "^2.0.1",
+        "@nextcloud/sharing": "^0.1.0",
         "@nextcloud/vue": "^7.11.4",
         "email-validator": "^2.0.4",
         "vue": "^2.7.14",
@@ -2312,6 +2313,14 @@
       "engines": {
         "node": "^16.0.0",
         "npm": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@nextcloud/sharing": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.1.0.tgz",
+      "integrity": "sha512-Cv4uc1aFrA18w0dltq7a5om/EbJSXf36rtO0LP3vi42E6l8ZDVCZwHLKrsZZa/TXNLeYErs1g/6tmWx5xiSSow==",
+      "dependencies": {
+        "core-js": "^3.6.4"
       }
     },
     "node_modules/@nextcloud/stylelint-config": {
@@ -14668,6 +14677,14 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.0.1.tgz",
       "integrity": "sha512-qLRxTjZS6y9NUPmU6X3Ega5qHPeEx4kCgqwo0I6Y9wV71EGGi9zPnWDsqmmmJj8RkDp30jcfGNWCTwbPAebTDA==",
+      "requires": {
+        "core-js": "^3.6.4"
+      }
+    },
+    "@nextcloud/sharing": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.1.0.tgz",
+      "integrity": "sha512-Cv4uc1aFrA18w0dltq7a5om/EbJSXf36rtO0LP3vi42E6l8ZDVCZwHLKrsZZa/TXNLeYErs1g/6tmWx5xiSSow==",
       "requires": {
         "core-js": "^3.6.4"
       }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@nextcloud/dialogs": "^4.0.1",
     "@nextcloud/event-bus": "^3.1.0",
     "@nextcloud/router": "^2.0.1",
+    "@nextcloud/sharing": "^0.1.0",
     "@nextcloud/vue": "^7.11.4",
     "email-validator": "^2.0.4",
     "vue": "^2.7.14",

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import Vue from 'vue'
 import GuestForm from './views/GuestForm.vue'
 import Nextcloud from './mixins/Nextcloud.js'
 import { showError } from '@nextcloud/dialogs'
+import { Type } from '@nextcloud/sharing'
 
 Vue.mixin(Nextcloud)
 
@@ -25,6 +26,7 @@ guestForm.$mount('#guest-root')
 const result = {
 	icon: 'icon-guests',
 	displayName: t('guests', 'Invite guest'),
+	shareType: Type.SHARE_TYPE_GUEST,
 	handler: async self => {
 		const user = self.suggestions.find(s => s.isNoUser === false && s.shareType === 0)
 		return new Promise((resolve, reject) => {


### PR DESCRIPTION
The object that is built in src/main.js which is added to the user search bar is used to build a share object and for this app the shareType is guest, hence it should be included from the source.

Related to : https://github.com/nextcloud/server/issues/40299