### PR TITLE
fix(config): Fix constructor of config class

### DIFF
--- a/.github/workflows/lint-php-cs.yml
+++ b/.github/workflows/lint-php-cs.yml
@@ -41,4 +41,4 @@ jobs:
         run: composer i
 
       - name: Lint
-        run: composer run cs:check || ( echo 'Please run `composer run cs:fix` to format your code' && exit 1 )
+        run: PHP_CS_FIXER_IGNORE_ENV=1 composer run cs:check || ( echo 'Please run `composer run cs:fix` to format your code' && exit 1 )

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
 Guests accounts can be created from the share menu by entering either the recipients email or name and choosing "create guest account", once the share is created the guest user will receive an email notification about the mail with a link to set their password.
 
 Guests users can only access files shared to them and cannot create any files outside of shares, additionally, the apps accessible to guest accounts are whitelisted.]]></description>
-	<version>3.0.1</version>
+	<version>3.1.0</version>
 	<licence>agpl</licence>
 	<author>Nextcloud</author>
 	<types>
@@ -26,7 +26,7 @@ Guests users can only access files shared to them and cannot create any files ou
 	<screenshot>https://raw.githubusercontent.com/nextcloud/guests/master/screenshots/settings.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/guests/master/screenshots/dropdown.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="28" max-version="28" />
+		<nextcloud min-version="29" max-version="29" />
 	</dependencies>
 	<commands>
 		<command>OCA\Guests\Command\ListCommand</command>

--- a/lib/AppConfigOverwrite.php
+++ b/lib/AppConfigOverwrite.php
@@ -24,7 +24,8 @@ declare(strict_types=1);
 namespace OCA\Guests;
 
 use OC\AppConfig;
-use OC\DB\ConnectionAdapter;
+use OCP\IDBConnection;
+use Psr\Log\LoggerInterface;
 
 class AppConfigOverwrite extends AppConfig {
 
@@ -32,10 +33,11 @@ class AppConfigOverwrite extends AppConfig {
 	private $overWrite;
 
 	public function __construct(
-		ConnectionAdapter $conn,
+		IDBConnection $connection,
+		LoggerInterface $logger,
 		array $overWrite
 	) {
-		parent::__construct($conn->getInner());
+		parent::__construct($connection, $logger);
 		$this->overWrite = $overWrite;
 	}
 

--- a/lib/RestrictionManager.php
+++ b/lib/RestrictionManager.php
@@ -33,6 +33,7 @@ use OCP\IServerContainer;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Settings\IManager;
+use Psr\Log\LoggerInterface;
 
 class RestrictionManager {
 	/** @var AppWhitelist */
@@ -119,11 +120,15 @@ class RestrictionManager {
 				$this->userBackend->setAllowListing(false);
 
 				$this->server->registerService(AppConfig::class, function () {
-					return new AppConfigOverwrite($this->server->get(IDBConnection::class), [
-						'core' => [
-							'shareapi_only_share_with_group_members' => 'yes'
+					return new AppConfigOverwrite(
+						$this->server->get(IDBConnection::class),
+						$this->server->get(LoggerInterface::class),
+						[
+							'core' => [
+								'shareapi_only_share_with_group_members' => 'yes'
+							]
 						]
-					]);
+					);
 				});
 			}
 		}

--- a/tests/stub.php
+++ b/tests/stub.php
@@ -130,8 +130,15 @@ namespace OC {
 	}
 
 	class AppConfig {
-		public function __construct(\OC\DB\Connection $connection) {
+		public function __construct(
+			protected \OCP\IDBConnection $connection,
+			private \Psr\Log\LoggerInterface $logger,
+		) {
 		}
+
+		/**
+		 * @deprecated - use getValue*()
+		 */
 		public function getValue(string $app, string $key, string $default = null): string {
 		}
 	}


### PR DESCRIPTION
From https://github.com/nextcloud/server/pull/41755

Makes at least the constructor pass again.

⚠️ This does not solve #1099 as the newly added functions still need to be overwritten.
But at least it does not break anymore