### PR TITLE
fix ListCommand: update for Symfony >=5 exit status

### DIFF
--- a/lib/Command/ListCommand.php
+++ b/lib/Command/ListCommand.php
@@ -44,7 +44,7 @@ class ListCommand extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output): void {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$guests = $this->guestManager->getGuestsInfo();
 
 		$outputType = $input->getOption('output');
@@ -54,7 +54,7 @@ class ListCommand extends Base {
 			} else {
 				$output->writeln("<info>No guests created</info>");
 			}
-			return;
+			return 0;
 		}
 
 		if ($outputType === self::OUTPUT_FORMAT_JSON || $outputType === self::OUTPUT_FORMAT_JSON_PRETTY) {
@@ -65,6 +65,6 @@ class ListCommand extends Base {
 			$table->setRows($guests);
 			$table->render();
 		}
-		return;
+		return 0;
 	}
 }


### PR DESCRIPTION
Fixes #1101

Return types required in Symfony >=5: https://symfony.com/blog/new-in-symfony-4-4-console-improvements#make-it-mandatory-to-return-the-command-exit-status
