### PR TITLE
Add 'direct' GET param to invite email 'view share' link

### DIFF
--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -110,7 +110,7 @@ class Mail {
 		$expiration = $share->getExpirationDate();
 
 		$link = $this->urlGenerator->linkToRouteAbsolute(
-			'files.viewcontroller.showFile', ['fileid' => $share->getNodeId()]
+			'files.viewcontroller.showFile', ['fileid' => $share->getNodeId(), 'direct' => 1]
 		);
 
 		$emailTemplate = $this->mailer->createEMailTemplate('guest.invite');


### PR DESCRIPTION
If user_saml or user_oidc are configured to automatically redirect the login page to an IdP, guests can't authenticate when clicking the link included in the share/invite email.

Adding the `direct=1` GET param to the `/f/FILE_ID` link works because the GET param is preserved when being redirected to the login page.

Should this be optional? I think it's fine to always have it since we know we want a direct login for guests.
Wdyt?