### PR TITLE
Fix tests

### DIFF
--- a/tests/stub.php
+++ b/tests/stub.php
@@ -796,6 +796,9 @@ namespace OC\Files\Storage\Wrapper{
 
 		public function getWatcher() {
 		}
+
+		public function setOwner(?string $user) : void {
+		}
 	}
 
 	class Jail extends Wrapper {


### PR DESCRIPTION
Static analysis tests are failing on `master` because of https://github.com/nextcloud/server/pull/44294
This should fix them.