### PR TITLE
fix(GuestForm): allow to create a guest without name more than once

### DIFF
--- a/src/views/GuestForm.vue
+++ b/src/views/GuestForm.vue
@@ -263,7 +263,7 @@ export default {
 		},
 
 		resetForm() {
-			this.guest.fullName = this.guest.username = this.guest.email = null
+			this.guest.fullName = this.guest.username = this.guest.email = ''
 		},
 
 		resetErrors() {


### PR DESCRIPTION
## Resolves

To reproduce - create a share with a guest without a name 2 times without page reloading.

- After creating a guest, the GuestForm modal is reset.
- During reset, values are set `null` instead of initial empty string `''`
- Then `null` is sent to the server that expects a string which causes an error

![image](https://github.com/nextcloud/guests/assets/25978914/92f8d66c-3ae1-4ad7-bb51-0eb7bf8b3fac)
