### PR TITLE
Add missing div id (fixes CSS lack)

### DIFF
--- a/src/components/GuestList.vue
+++ b/src/components/GuestList.vue
@@ -1,6 +1,6 @@
 <template>
 	<NcSettingsSection :name="t('guests', 'Guests accounts')">
-		<div v-if="loaded && !error">
+		<div class="guests-list" v-if="loaded && !error">
 			<table v-if="guests.length" class="table">
 				<thead>
 					<tr>
@@ -121,7 +121,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-#guests-list {
+.guests-list {
 	padding: 20px 0 0;
 
 	table {


### PR DESCRIPTION
Tests from reviewers are welcome.

### Before (without id)
![2024-08-19_13-34](https://github.com/user-attachments/assets/d3db6a83-eee9-4b34-a193-35b63b4e14de)

### After (with id = CSS applies correctly)
![2024-08-19_13-34_1](https://github.com/user-attachments/assets/e126207f-5ee1-43d0-be62-049e7bf5b952)
