### PR TITLE
v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## 3.0.2
+### Fixes
+* [stable28] fix(GuestForm): allow to create a guest without name more than once by @backportbot in https://github.com/nextcloud/guests/pull/1179
+* [stable28] chore: add changelog for 2.4.0 .. 3.0.1 by @ShGKme in https://github.com/nextcloud/guests/pull/1184
+* [stable28] fix(Sharing): Do not create new share in guest app  by @backportbot in https://github.com/nextcloud/guests/pull/1192
+
+### Dependencies
+* Chore(deps): Bump follow-redirects from 1.15.3 to 1.15.4 by @dependabot in https://github.com/nextcloud/guests/pull/1097
+
+**Full Changelog**: https://github.com/nextcloud/guests/compare/v3.0.1...v3.0.2
+
 ## 3.0.1
 ### What's Changed
 * 3.0.1 by @icewind1991 in https://github.com/nextcloud/guests/pull/1082
@@ -9,7 +20,6 @@ All notable changes to this project will be documented in this file.
 **Full Changelog**: https://github.com/nextcloud/guests/compare/v3.0.0...v3.0.1
 
 ## 3.0.0
-
 ### What's Changed
 * feat(deps): Add Nextcloud 28 support by @nickvergessen in https://github.com/nextcloud/guests/pull/1026
 * Fix event dispatcher usage by @nickvergessen in https://github.com/nextcloud/guests/pull/1045

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
 Guests accounts can be created from the share menu by entering either the recipients email or name and choosing "create guest account", once the share is created the guest user will receive an email notification about the mail with a link to set their password.
 
 Guests users can only access files shared to them and cannot create any files outside of shares, additionally, the apps accessible to guest accounts are whitelisted.]]></description>
-	<version>3.0.1</version>
+	<version>3.0.2</version>
 	<licence>agpl</licence>
 	<author>Nextcloud</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "guests",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "guests",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "license": "agpl",
       "dependencies": {
         "@nextcloud/axios": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guests",
   "description": "Create guest users which can only see files shared with them",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "author": "Robin Appelman <robin@icewind.nl>",
   "contributors": [
     "Robin Appelman <robin@icewind.nl>",


### PR DESCRIPTION
## 3.0.2
### Fixes
* [stable28] fix(GuestForm): allow to create a guest without name more than once by @backportbot in https://github.com/nextcloud/guests/pull/1179
* [stable28] chore: add changelog for 2.4.0 .. 3.0.1 by @ShGKme in https://github.com/nextcloud/guests/pull/1184
* [stable28] fix(Sharing): Do not create new share in guest app  by @backportbot in https://github.com/nextcloud/guests/pull/1192

### Dependencies
* Chore(deps): Bump follow-redirects from 1.15.3 to 1.15.4 by @dependabot in https://github.com/nextcloud/guests/pull/1097

**Full Changelog**: https://github.com/nextcloud/guests/compare/v3.0.1...v3.0.2