### PR TITLE
fix(notifications): Notifier::prepare() threw \InvalidArgumentExcepti…

### DIFF
--- a/lib/Notifications/Notifier.php
+++ b/lib/Notifications/Notifier.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
 
 namespace OCA\Guests\Notifications;
 
-use InvalidArgumentException;
 use OCA\Guests\AppInfo\Application;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class Notifier implements INotifier {
 	public function __construct(
@@ -51,12 +51,12 @@ class Notifier implements INotifier {
 	}
 
 	/**
-	 * @throws InvalidArgumentException
+	 * @throws UnknownNotificationException
 	 */
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== Application::APP_ID) {
 			// Not my app => throw
-			throw new InvalidArgumentException();
+			throw new UnknownNotificationException();
 		}
 
 		// Read the language from the notification
@@ -95,7 +95,7 @@ class Notifier implements INotifier {
 
 			default:
 				// Unknown subject => Unknown notification => throw
-				throw new InvalidArgumentException();
+				throw new UnknownNotificationException();
 		}
 	}
 }


### PR DESCRIPTION
…on which is deprecated

If a user has any notifications this log is generated all the time:

> OCA\…\Notification\Notifier::prepare() threw \InvalidArgumentException which is deprecated. Throw \OCP\Notification\UnknownNotificationException when the notification is not known to your notifier and otherwise handle all \InvalidArgumentException yourself.