### PR TITLE
feat: always allow twofactor apps

### DIFF
--- a/lib/AppWhitelist.php
+++ b/lib/AppWhitelist.php
@@ -25,7 +25,7 @@ class AppWhitelist {
 	private string $baseUrl;
 	private int $baseUrlLength;
 
-	public const WHITELIST_ALWAYS = ',core,theming,settings,avatar,files,heartbeat,dav,guests,impersonate,accessibility,terms_of_service,dashboard,weather_status,user_status,apporder';
+	public const WHITELIST_ALWAYS = ',core,theming,settings,avatar,files,heartbeat,dav,guests,impersonate,accessibility,terms_of_service,dashboard,weather_status,user_status,apporder,twofactor_totp,twofactor_webauthn,twofactor_backupcodes,twofactor_nextcloud_notification';
 
 	public const DEFAULT_WHITELIST = 'files_trashbin,files_versions,files_sharing,files_texteditor,text,activity,firstrunwizard,photos,notifications,dashboard,user_status,weather_status';
 


### PR DESCRIPTION
Ref https://github.com/nextcloud/guests/issues/149#issuecomment-557023354
Ref https://github.com/nextcloud/guests/issues/1249

## Problem

A guest user will not be able to set up their second factor authentication method by default, e.g. TOTP and Webauthn. Admins have to specifically add the corresponding `twofactor_*` apps to the white list first.

Instead, attempting to enable, disable a second factor method or generating backup codes as a user will yield a cryptic internal server error response with no context. However, if a method is set up and the app is removed from the white list, the login will still work.

### How to reproduce?

1. Create a guest user.
2. Install at least one twofactor app, e.g. twofactor_totp.
3. Enable the app white list for guest users and remove twofactor_totp from it.
4. Log in as the guest user.
5. Try to set up TOTP.

Observe `500 Internal Server Error` responses.

## Solution

Allow supported twofactor apps by default:
- twofactor_webauthn
- twofactor_totp
- twofactor_backupcodes
- twofactor_nextcloud_notifications