### PR TITLE
feat: Add share count including circles

### DIFF
--- a/lib/GuestManager.php
+++ b/lib/GuestManager.php
@@ -113,11 +113,19 @@ class GuestManager {
 		$shareCounts = $this->getShareCountForUsers($guests);
 		$createdBy = $this->config->getUserValueForUsers('guests', 'created_by', $guests);
 		return array_map(function ($uid) use ($createdBy, $displayNames, $shareCounts) {
+			$allSharesCount = count(array_merge(
+				$this->shareManager->getSharedWith($uid, IShare::TYPE_USER, null, -1, 0),
+				$this->shareManager->getSharedWith($uid, IShare::TYPE_GROUP, null, -1, 0),
+				$this->shareManager->getSharedWith($uid, IShare::TYPE_CIRCLE, null, -1, 0),
+				$this->shareManager->getSharedWith($uid, IShare::TYPE_GUEST, null, -1, 0),
+				$this->shareManager->getSharedWith($uid, IShare::TYPE_ROOM, null, -1, 0),
+			));
 			return [
 				'email' => $uid,
 				'display_name' => $displayNames[$uid] ?? $uid,
 				'created_by' => $createdBy[$uid] ?? '',
 				'share_count' => isset($shareCounts[$uid]) ? $shareCounts[$uid] : 0,
+				'share_count_with_circles' => $allSharesCount,
 			];
 		}, $guests);
 	}


### PR DESCRIPTION
The number of shares returned from `/api/v1/users` did not match the count from `/api/v1/users/<user>` as it didn't include circle shares

This adds a new property which includes the shares via circles