### PR TITLE
fix: Set guest quota to '0 B' when migrating form OC

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,8 +4,8 @@
   - SPDX-FileCopyrightText: 2015-2017 ownCloud GmbH
   - SPDX-License-Identifier: AGPL-3.0-only AND (AGPL-3.0-or-later OR AGPL-3.0-only)
 -->
-<info xmlns:xsi= "http://www.w3.org/2001/XMLSchema-instance"
-	  xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
 	<id>guests</id>
 	<name>Guests</name>
 	<summary>Create guest accounts for easier collaboration</summary>
@@ -18,7 +18,7 @@ Guests users can only access files shared to them and cannot create any files ou
 	<licence>agpl</licence>
 	<author>Nextcloud</author>
 	<types>
-		<authentication/>
+		<authentication />
 	</types>
 	<documentation>
 		<admin>https://github.com/nextcloud/guests/blob/master/README.md</admin>
@@ -34,9 +34,9 @@ Guests users can only access files shared to them and cannot create any files ou
 		<nextcloud min-version="30" max-version="32" />
 	</dependencies>
 	<repair-steps>
-		<pre-migration>
+		<post-migration>
 			<step>OCA\Guests\Migration\OwncloudGuestsMigration</step>
-		</pre-migration>
+		</post-migration>
 	</repair-steps>
 	<commands>
 		<command>OCA\Guests\Command\ListCommand</command>

--- a/lib/Migration/OwncloudGuestsMigration.php
+++ b/lib/Migration/OwncloudGuestsMigration.php
@@ -58,7 +58,8 @@ class OwncloudGuestsMigration implements IRepairStep {
 	 * 1. Create a new guest with the same username and password
 	 * 2. register a new transfer
 	 * 3. Delete the old user
-	 * 4. Delete the old 'isGuest' prference row
+	 * 4. Delete the old 'isGuest' preference row
+	 * 5. Set the quota to '0 B'
 	 */
 	protected function runStep(IOutput $output) {
 		$output->startProgress(count($this->cachedUserIDs));
@@ -73,6 +74,13 @@ class OwncloudGuestsMigration implements IRepairStep {
 					$oldBackend->deleteUser($ocGuest->getUID());
 
 					$this->config->deleteUserValue($userID, 'owncloud', 'isGuest');
+
+					$guestUser = $this->userManager->get($userID);
+					if ($guestUser) {
+						$guestUser->setQuota('0 B');
+					} else {
+						$output->warning("Could not set quota for guest $userID");
+					}
 				} else {
 					$output->warning("Could not get hashed password for guest $userID, skipping");
 				}


### PR DESCRIPTION
@skjnldsv any reason why you set the repair step to run pre migrations? This causes the `oc_guests_users` table to be not existing. I assume it was working when you first developed the repair step, not sure what changed since then.
