### PR TITLE
feat: Hash user IDs by default for improved privacy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ js
 .vscode
 .php_cs.cache
 .php-cs-fixer.cache
+.phpunit.result.cache

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@
 Guests accounts can be created from the share menu by entering either the recipients email or name and choosing "create guest account", once the share is created the guest user will receive an email notification about the mail with a link to set their password.
 
 Guests users can only access files shared to them and cannot create any files outside of shares, additionally, the apps accessible to guest accounts are whitelisted.]]></description>
-	<version>4.7.0-dev.0</version>
+	<version>4.7.0-dev.1</version>
 	<licence>agpl</licence>
 	<author>Nextcloud</author>
 	<types>

--- a/lib/Command/AddCommand.php
+++ b/lib/Command/AddCommand.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Guests\Command;
 
+use OCA\Guests\Config;
 use OCA\Guests\GuestManager;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -27,6 +28,7 @@ class AddCommand extends Command {
 		private readonly IUserManager $userManager,
 		private readonly IMailer $mailer,
 		private readonly GuestManager $guestManager,
+		private readonly Config $config,
 	) {
 		parent::__construct();
 	}
@@ -83,14 +85,20 @@ class AddCommand extends Command {
 			return self::FAILURE;
 		}
 
+		$email = $input->getArgument('email');
+		if ($this->config->useHashedEmailAsUserID()) {
+			$email = strtolower($email);
+			$uid = hash('sha256', $email);
+		} else {
+			$uid = $email;
+		}
+
 		// same behavior like in the UsersController
-		$uid = $input->getArgument('email');
 		if ($this->userManager->userExists($uid)) {
 			$output->writeln('<error>The user "' . $uid . '" already exists.</error>');
 			return self::FAILURE;
 		}
 
-		$email = $input->getArgument('email');
 		if (!$this->mailer->validateMailAddress($email)) {
 			$output->writeln('<error>Invalid email address "' . $email . '".</error>');
 			return self::FAILURE;

--- a/lib/Command/ListCommand.php
+++ b/lib/Command/ListCommand.php
@@ -49,7 +49,7 @@ class ListCommand extends Base {
 			$this->writeArrayInOutputFormat($input, $output, $guests);
 		} else {
 			$table = new Table($output);
-			$table->setHeaders(['Email', 'Name', 'Invited By']);
+			$table->setHeaders(['Email', 'UserID', 'Name', 'Invited By']);
 			$table->setRows($guests);
 			$table->render();
 		}

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -33,6 +33,14 @@ class Config {
 		$this->appConfig->setAppValueBool('allow_external_storage', $allow === true || $allow === 'true') ;
 	}
 
+	public function useHashedEmailAsUserID(): bool {
+		return $this->appConfig->getAppValueBool('hash_user_ids', true);
+	}
+
+	public function setUseHashedEmailAsUserID(bool $useHash): void {
+		$this->appConfig->setAppValueBool('hash_user_ids', $useHash) ;
+	}
+
 	public function hideOtherUsers(): bool {
 		return $this->appConfig->getAppValueBool('hide_users', true);
 	}

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -48,6 +48,7 @@ class SettingsController extends Controller {
 			'useWhitelist' => $useWhitelist,
 			'whitelist' => $whitelist,
 			'allowExternalStorage' => $allowExternalStorage,
+			'useHashedEmailAsUserID' => $this->config->useHashedEmailAsUserID(),
 			'hideUsers' => $hideUsers,
 			'whiteListableApps' => $this->appWhitelist->getWhitelistAbleApps(),
 			'sharingRestrictedToGroup' => $this->config->isSharingRestrictedToGroup(),
@@ -58,7 +59,7 @@ class SettingsController extends Controller {
 	/**
 	 * @param list<string> $whitelist
 	 */
-	public function setConfig(bool $useWhitelist, array $whitelist, bool $allowExternalStorage, bool $hideUsers, array $createRestrictedToGroup): DataResponse {
+	public function setConfig(bool $useWhitelist, array $whitelist, bool $allowExternalStorage, bool $useHashedEmailAsUserID, bool $hideUsers, array $createRestrictedToGroup): DataResponse {
 		$newWhitelist = [];
 		foreach ($whitelist as $app) {
 			$newWhitelist[] = trim((string)$app);
@@ -67,6 +68,7 @@ class SettingsController extends Controller {
 		$this->config->setUseWhitelist($useWhitelist);
 		$this->config->setAppWhitelist($newWhitelist);
 		$this->config->setAllowExternalStorage($allowExternalStorage);
+		$this->config->setUseHashedEmailAsUserID($useHashedEmailAsUserID);
 		$this->config->setHideOtherUsers($hideUsers);
 		$this->config->setCreateRestrictedToGroup($createRestrictedToGroup);
 

--- a/lib/Controller/UsersController.php
+++ b/lib/Controller/UsersController.php
@@ -111,7 +111,12 @@ class UsersController extends OCSController {
 			);
 		}
 
-		$username = $email;
+		if ($this->config->useHashedEmailAsUserID()) {
+			$email = strtolower($email);
+			$username = hash('sha256', $email);
+		} else {
+			$username = $email;
+		}
 
 		$existingUsers = $this->userManager->getByEmail($email);
 		if (count($existingUsers) > 0) {

--- a/lib/GuestManager.php
+++ b/lib/GuestManager.php
@@ -69,6 +69,7 @@ class GuestManager {
 			return null;
 		}
 
+		$this->userBackend->setInitialEmail($userId, $email);
 		$user->setSystemEMailAddress($email);
 		if ($createdBy instanceof IUser) {
 			$this->config->setUserValue($userId, 'guests', 'created_by', $createdBy->getUID());
@@ -125,11 +126,11 @@ class GuestManager {
 	 * }>
 	 */
 	public function getGuestsInfo(): array {
-		$displayNames = $this->userBackend->getDisplayNames();
-		$guests = array_keys($displayNames);
+		$guestsInfo = $this->userBackend->getAllGuestAccounts();
+		$guests = array_keys($guestsInfo);
 		$shareCounts = $this->getShareCountForUsers($guests);
 		$createdBy = $this->config->getUserValueForUsers('guests', 'created_by', $guests);
-		return array_map(function (string $uid) use ($createdBy, $displayNames, $shareCounts): array {
+		return array_map(function (string $uid) use ($createdBy, $guestsInfo, $shareCounts): array {
 			$allSharesCount = count(array_merge(
 				$this->shareManager->getSharedWith($uid, IShare::TYPE_USER, null, -1, 0),
 				$this->shareManager->getSharedWith($uid, IShare::TYPE_GROUP, null, -1, 0),
@@ -138,8 +139,9 @@ class GuestManager {
 				$this->shareManager->getSharedWith($uid, IShare::TYPE_ROOM, null, -1, 0),
 			));
 			return [
-				'email' => $uid,
-				'display_name' => $displayNames[$uid] ?? $uid,
+				'email' => $guestsInfo[$uid]['email'] ?? $uid,
+				'uid' => $uid,
+				'display_name' => $guestsInfo[$uid]['displayname'] ?? $uid,
 				'created_by' => $createdBy[$uid] ?? '',
 				'share_count' => $shareCounts[$uid] ?? 0,
 				'share_count_with_circles' => $allSharesCount,

--- a/lib/Migration/Version4002Date20250501195008.php
+++ b/lib/Migration/Version4002Date20250501195008.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Guests\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Add a column for the email so we know the originally invited email as well
+ */
+class Version4002Date20250501195008 extends SimpleMigrationStep {
+	public function __construct(
+		protected IDBConnection $db,
+	) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('guests_users');
+		if ($table->hasColumn('email')) {
+			return null;
+		}
+
+		$table->addColumn('email', 'string', [
+			'notnull' => false,
+			'length' => 64,
+			'default' => '',
+		]);
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$query = $this->db->getQueryBuilder();
+		$query->update('guests_users')
+			->set('email', 'uid_lower');
+		$query->executeStatement();
+	}
+}

--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -103,6 +103,14 @@ class UserBackend extends ABackend implements
 		return (bool)$result;
 	}
 
+	public function setInitialEmail(string $uid, string $email): bool {
+		$query = $this->dbConn->getQueryBuilder();
+		$query->update('guests_users')
+			->set('email', $query->createNamedParameter($email))
+			->where($query->expr()->eq('uid_lower', $query->createNamedParameter(mb_strtolower($uid))));
+		return (bool)$query->executeStatement();
+	}
+
 	/**
 	 * Change the password of a user
 	 */
@@ -232,13 +240,42 @@ class UserBackend extends ABackend implements
 	}
 
 	/**
+	 * Get a list of all users with their email and display name
+	 *
+	 * @return array<string, array{email: string, displayname: string}>
+	 */
+	public function getAllGuestAccounts(?int $limit = null, ?int $offset = null): array {
+		if (!$this->allowListing) {
+			return [];
+		}
+
+		$query = $this->dbConn->getQueryBuilder();
+		$query->select('uid', 'email', 'displayname')
+			->from('guests_users')
+			->orderBy('uid_lower', 'ASC')
+			->setMaxResults($limit)
+			->setFirstResult($offset);
+
+		$result = $query->executeQuery();
+		$users = [];
+		while ($row = $result->fetch()) {
+			$users[(string)$row['uid']] = [
+				'email' => (string)$row['email'],
+				'displayname' => (string)$row['displayname'],
+			];
+		}
+
+		return $users;
+	}
+
+	/**
 	 * Check if the password is correct without logging in the user
 	 * returns the user id or false
 	 *
 	 * @return string|false
 	 */
 	public function checkPassword(string $loginName, string $password) {
-		if (!str_contains($loginName, '@')) {
+		if (!$this->potentialGuestUserId($loginName)) {
 			return false;
 		}
 
@@ -275,9 +312,13 @@ class UserBackend extends ABackend implements
 	 * @param string $uid the username
 	 */
 	private function loadUser($uid): bool {
+		if (isset($this->cache[$uid]) && $this->cache[$uid] === false) {
+			return false;
+		}
+
 		// guests $uid could be NULL or ''
 		// or is not an email anyway
-		if (!str_contains($uid, '@')) {
+		if (!$this->potentialGuestUserId($uid)) {
 			$this->cache[$uid] = false;
 			return false;
 		}
@@ -390,7 +431,7 @@ class UserBackend extends ABackend implements
 	}
 
 	public function getRealUID(string $uid): string {
-		if (!str_contains($uid, '@')) {
+		if (!$this->potentialGuestUserId($uid)) {
 			throw new \RuntimeException($uid . ' does not exist');
 		}
 
@@ -403,5 +444,17 @@ class UserBackend extends ABackend implements
 		}
 
 		return $this->cache[$uid]['uid'];
+	}
+
+	/**
+	 * Guest app user ids are:
+	 * - either email addresses so they need to contain an @
+	 * - lowercase sha256 hashes of email addresses, 64 characters of a-f and 0-9
+	 *
+	 * @param string $userId
+	 * @return bool
+	 */
+	protected function potentialGuestUserId(string $userId): bool {
+		return str_contains($userId, '@') || preg_match('/^[a-f0-9]{64}$/', $userId);
 	}
 }

--- a/src/components/GuestList.vue
+++ b/src/components/GuestList.vue
@@ -11,6 +11,9 @@
 						<th :class="getSortClass('email')" @click="setSort('email')">
 							{{ t('guests', 'Email') }}
 						</th>
+						<th :class="getSortClass('uid')" @click="setSort('uid')">
+							{{ t('guests', 'User ID') }}
+						</th>
 						<th :class="getSortClass('display_name')" @click="setSort('display_name')">
 							{{ t('guests', 'Name') }}
 						</th>
@@ -31,6 +34,10 @@
 								:title="guest.email">
 								{{ guest.email }}
 							</td>
+							<td class="uid"
+								:title="guest.uid">
+								{{ guest.uid }}
+							</td>
 							<td class="display_name"
 								:title="guest.display_name">
 								{{ guest.display_name }}
@@ -46,7 +53,7 @@
 						<tr v-if="guest.email === details_for"
 							:key="guest.email + '-details'"
 							class="details">
-							<td colspan="4">
+							<td colspan="5">
 								<GuestDetails :guest-id="guest.email" />
 							</td>
 						</tr>

--- a/src/views/GuestSettings.vue
+++ b/src/views/GuestSettings.vue
@@ -39,6 +39,12 @@
 					{{ t('guests', 'Guest accounts can access mounted external storages') }}
 				</NcCheckboxRadioSwitch>
 
+				<NcCheckboxRadioSwitch :checked.sync="config.useHashedEmailAsUserID"
+					type="switch"
+					@update:checked="saveConfig">
+					{{ t('guests', 'Use a hash of the email as user ID for improved privacy') }}
+				</NcCheckboxRadioSwitch>
+
 				<NcCheckboxRadioSwitch :checked.sync="config.hideUsers"
 					type="switch"
 					@update:checked="saveConfig">
@@ -133,6 +139,7 @@ export default {
 			config: {
 				useWhitelist: false,
 				allowExternalStorage: false,
+				useHashedEmailAsUserID: true,
 				hideUsers: false,
 				whitelist: [],
 				whiteListableApps: [],

--- a/tests/unit/Command/AddCommandTest.php
+++ b/tests/unit/Command/AddCommandTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Guests\Test\Command\Unit;
 
 use OCA\Guests\Command\AddCommand;
+use OCA\Guests\Config;
 use OCA\Guests\GuestManager;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -19,14 +20,10 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
 
 class AddCommandTest extends TestCase {
-	/** @var IUserManager|MockObject */
-	private $userManager;
-
-	/** @var GuestManager|MockObject */
-	private $guestManager;
-
-	/** @var IMailer|MockObject */
-	private $mailer;
+	private IUserManager&MockObject $userManager;
+	private GuestManager&MockObject $guestManager;
+	private IMailer&MockObject $mailer;
+	private Config&MockObject $config;
 
 	private ?AddCommand $command = null;
 
@@ -38,11 +35,13 @@ class AddCommandTest extends TestCase {
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->guestManager = $this->createMock(GuestManager::class);
 		$this->mailer = $this->createMock(IMailer::class);
+		$this->config = $this->createMock(Config::class);
 
 		$this->command = new AddCommand(
 			$this->userManager,
 			$this->mailer,
-			$this->guestManager
+			$this->guestManager,
+			$this->config,
 		);
 		$this->command->setApplication(new Application());
 

--- a/tests/unit/Migration/OwncloudGuestMigrationTest.php
+++ b/tests/unit/Migration/OwncloudGuestMigrationTest.php
@@ -45,6 +45,7 @@ class OwncloudGuestMigrationTest extends TestCase {
 	}
 
 	private function createOcGuest(string $userId): void {
+		$this->userManager->get($userId)?->delete();
 		$this->userManager->createUser($userId, $userId . '_password');
 		$this->config->setUserValue($userId, 'owncloud', 'isGuest', '1');
 	}


### PR DESCRIPTION
 - Enabled by default, but optional
 - Improves privacy of guests as their user id does not automatically leak their email address (e.g. avatars in chats and more)