### PR TITLE
chore: prepare 4.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## 4.3.0
+### Changes
+* feat: Add share count including circles by @Pytal in https://github.com/nextcloud/guests/pull/1287
+* feat: allow limiting guests creation to specific groups by @skjnldsv in https://github.com/nextcloud/guests/pull/1330
+
+### Fixes
+* fix: fix DirMask path check by @icewind1991 in https://github.com/nextcloud/guests/pull/1311
+* fix: Set guest quota to '0 B' when migrating form OC by @artonge in https://github.com/nextcloud/guests/pull/1310
+* fix(settings): ellipsis long table cells by @skjnldsv in https://github.com/nextcloud/guests/pull/1321
+
+### Other
+* Chore(deps): Bump @babel/runtime from 7.26.9 to 7.27.0
+* Chore(deps): Bump @nextcloud/dialogs from 6.1.1 to 6.3.1
+* Chore(deps): Bump @nextcloud/event-bus from 3.3.1 to 3.3.2
+* Chore(deps): Bump @nextcloud/vue from 8.23.1 to 8.27.0
+* Chore(deps): Bump axios from 1.7.9 to 1.8.3
+* Various dependencies
+
+**Full Changelog**: https://github.com/nextcloud/guests/compare/v4.2.0...v4.3.0
+
 ## 4.2.0
 
 ### Changes

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@
 Guests accounts can be created from the share menu by entering either the recipients email or name and choosing "create guest account", once the share is created the guest user will receive an email notification about the mail with a link to set their password.
 
 Guests users can only access files shared to them and cannot create any files outside of shares, additionally, the apps accessible to guest accounts are whitelisted.]]></description>
-	<version>4.2.0</version>
+	<version>4.3.0</version>
 	<licence>agpl</licence>
 	<author>Nextcloud</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "guests",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "guests",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "license": "agpl",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guests",
   "description": "Create guest users which can only see files shared with them",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "type": "module",
   "author": "Robin Appelman <robin@icewind.nl>",
   "contributors": [


### PR DESCRIPTION
## 4.3.0
### Changes
* feat: Add share count including circles by @Pytal in https://github.com/nextcloud/guests/pull/1287
* feat: allow limiting guests creation to specific groups by @skjnldsv in https://github.com/nextcloud/guests/pull/1330

### Fixes
* fix: fix DirMask path check by @icewind1991 in https://github.com/nextcloud/guests/pull/1311
* fix: Set guest quota to '0 B' when migrating form OC by @artonge in https://github.com/nextcloud/guests/pull/1310
* fix(settings): ellipsis long table cells by @skjnldsv in https://github.com/nextcloud/guests/pull/1321

### Other
* Chore(deps): Bump @babel/runtime from 7.26.9 to 7.27.0
* Chore(deps): Bump @nextcloud/dialogs from 6.1.1 to 6.3.1
* Chore(deps): Bump @nextcloud/event-bus from 3.3.1 to 3.3.2
* Chore(deps): Bump @nextcloud/vue from 8.23.1 to 8.27.0
* Chore(deps): Bump axios from 1.7.9 to 1.8.3
* Various dependencies

**Full Changelog**: https://github.com/nextcloud/guests/compare/v4.2.0...v4.3.0