### PR TITLE
fix: accept INavigationManager instead of NavigationManager in Filter…

### DIFF
--- a/lib/FilteredNavigationManager.php
+++ b/lib/FilteredNavigationManager.php
@@ -9,21 +9,15 @@ namespace OCA\Guests;
 
 use OC\NavigationManager;
 use OCP\IUser;
+use OCP\INavigationManager;
 
 class FilteredNavigationManager extends NavigationManager {
-	/** @var AppWhitelist */
-	private $whitelist;
 
-	/** @var IUser */
-	private $user;
-
-	/** @var NavigationManager */
-	private $navigationManager;
-
-	public function __construct(IUser $user, NavigationManager $navigationManager, AppWhitelist $whitelist) {
-		$this->whitelist = $whitelist;
-		$this->user = $user;
-		$this->navigationManager = $navigationManager;
+	public function __construct(
+        private IUser $user,
+        private INavigationManager $navigationManager,
+        private AppWhitelist $whitelist
+    ) {
 	}
 
 	public function getAll(string $type = 'link'): array {


### PR DESCRIPTION
### Description

This pull request updates the constructor of `FilteredNavigationManager` to accept an `INavigationManager` interface as its second argument, instead of the concrete `NavigationManager` class.

This change improves compatibility with proxy or decorated navigation manager implementations (such as custom proxies in other apps), and increases overall flexibility and interoperability.

### Context

- Previously, the constructor required a concrete `NavigationManager`, which caused issues when passing an implementation of `INavigationManager` (e.g., a proxy or decorator).
- This PR allows any object implementing `INavigationManager` to be used.

### How to test

1. Install the Guests app and an app that provides a custom/proxy implementation of `INavigationManager`.
2. Ensure the app works as expected and navigation items are displayed correctly.
