### PR TITLE
fix: accept INavigationManager instead of NavigationManager in Filter…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
 		"cs:fix": "php-cs-fixer fix",
 		"psalm": "psalm --threads=1",
 		"psalm:update-baseline": "psalm --threads=1 --update-baseline",
+		"psalm:update-baseline:force": "psalm --threads=1 --update-baseline --set-baseline=tests/psalm-baseline.xml",
 		"psalm:clear": "psalm --clear-cache && psalm --clear-global-cache",
 		"psalm:fix": "psalm --alter --issues=InvalidReturnType,InvalidNullableReturnType,MismatchingDocblockParamType,MismatchingDocblockReturnType,MissingParamType,InvalidFalsableReturnType",
 		"test:unit": "vendor/bin/phpunit -c phpunit.xml"

--- a/lib/FilteredNavigationManager.php
+++ b/lib/FilteredNavigationManager.php
@@ -8,22 +8,16 @@
 namespace OCA\Guests;
 
 use OC\NavigationManager;
+use OCP\INavigationManager;
 use OCP\IUser;
 
 class FilteredNavigationManager extends NavigationManager {
-	/** @var AppWhitelist */
-	private $whitelist;
 
-	/** @var IUser */
-	private $user;
-
-	/** @var NavigationManager */
-	private $navigationManager;
-
-	public function __construct(IUser $user, NavigationManager $navigationManager, AppWhitelist $whitelist) {
-		$this->whitelist = $whitelist;
-		$this->user = $user;
-		$this->navigationManager = $navigationManager;
+	public function __construct(
+		private IUser $user,
+		private INavigationManager $navigationManager,
+		private AppWhitelist $whitelist,
+	) {
 	}
 
 	public function getAll(string $type = 'link'): array {

--- a/lib/FilteredNavigationManager.php
+++ b/lib/FilteredNavigationManager.php
@@ -50,14 +50,23 @@ class FilteredNavigationManager extends NavigationManager {
 		$this->navigationManager->setUnreadCounter($id, $unreadCounter);
 	}
 
+	/**
+	 * @psalm-suppress MethodSignatureMismatch
+	 */
 	public function get(string $id): ?array {
 		return $this->navigationManager->get($id);
 	}
 
+	/**
+	 * @psalm-suppress MethodSignatureMismatch
+	 */
 	public function getDefaultEntryIdForUser(?IUser $user = null, bool $withFallbacks = true): string {
 		return $this->navigationManager->getDefaultEntryIdForUser($user, $withFallbacks);
 	}
 
+	/**
+	 * @psalm-suppress MethodSignatureMismatch
+	 */
 	public function getDefaultEntryIds(bool $withFallbacks = true): array {
 		return $this->navigationManager->getDefaultEntryIds($withFallbacks);
 	}

--- a/lib/Storage/DirMask.php
+++ b/lib/Storage/DirMask.php
@@ -56,7 +56,7 @@ class DirMask extends PermissionsMask {
 		}
 	}
 
-	public function isCreatable(string $path): bool {
+	public function isCreatable($path): bool {
 		if ($this->checkPath($path)) {
 			return parent::isCreatable($path);
 		} else {

--- a/lib/Storage/DirMask.php
+++ b/lib/Storage/DirMask.php
@@ -44,7 +44,7 @@ class DirMask extends PermissionsMask {
 		$this->mask = $arguments['mask'];
 	}
 
-	protected function checkPath($path): bool {
+	protected function checkPath(string $path): bool {
 		return $path === $this->path || substr($path, 0, $this->pathLength + 1) === $this->path . '/';
 	}
 
@@ -56,7 +56,7 @@ class DirMask extends PermissionsMask {
 		}
 	}
 
-	public function isCreatable($path): bool {
+	public function isCreatable(string $path): bool {
 		if ($this->checkPath($path)) {
 			return parent::isCreatable($path);
 		} else {

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -4,27 +4,9 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
-  <file src="lib/AppConfigOverwrite.php">
-    <MethodSignatureMismatch>
-      <code><![CDATA[public function getValue($app, $key, $default = null) {]]></code>
-    </MethodSignatureMismatch>
-  </file>
   <file src="lib/AppInfo/Application.php">
     <UndefinedInterfaceMethod>
       <code><![CDATA[listen]]></code>
     </UndefinedInterfaceMethod>
-  </file>
-  <file src="lib/FilteredNavigationManager.php">
-    <TooManyArguments>
-      <code><![CDATA[getDefaultEntryIds]]></code>
-    </TooManyArguments>
-    <UndefinedInterfaceMethod>
-      <code><![CDATA[clear]]></code>
-    </UndefinedInterfaceMethod>
-  </file>
-  <file src="lib/RestrictionManager.php">
-    <UndefinedClass>
-      <code><![CDATA[ExternalMountPoint]]></code>
-    </UndefinedClass>
   </file>
 </files>

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -4,9 +4,22 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
+  <file src="lib/AppConfigOverwrite.php">
+    <MethodSignatureMismatch>
+      <code><![CDATA[public function getValue($app, $key, $default = null) {]]></code>
+    </MethodSignatureMismatch>
+  </file>
   <file src="lib/AppInfo/Application.php">
     <UndefinedInterfaceMethod>
       <code><![CDATA[listen]]></code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/FilteredNavigationManager.php">
+    <TooManyArguments>
+      <code><![CDATA[getDefaultEntryIds]]></code>
+    </TooManyArguments>
+    <UndefinedInterfaceMethod>
+      <code><![CDATA[clear]]></code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/RestrictionManager.php">

--- a/tests/stub.php
+++ b/tests/stub.php
@@ -827,3 +827,8 @@ namespace OCA\Settings\Events {
 	class BeforeTemplateRenderedEvent extends Event {
 	}
 }
+
+namespace OCA\Files_External\Config {
+	class ExternalMountPoint {
+	}
+}


### PR DESCRIPTION
### Description

This pull request updates the constructor of `FilteredNavigationManager` to accept an `INavigationManager` interface as its second argument, instead of the concrete `NavigationManager` class.

This change improves compatibility with proxy or decorated navigation manager implementations (such as custom proxies in other apps), and increases overall flexibility and interoperability.

### Context

- Previously, the constructor required a concrete `NavigationManager`, which caused issues when passing an implementation of `INavigationManager` (e.g., a proxy or decorator).
- This PR allows any object implementing `INavigationManager` to be used.
- 
**Signed-off-by:**  
[Your Name] `<your.email@example.com>`