### PR TITLE
fix: add IConfig for AppConfigOverwrite

### DIFF
--- a/lib/AppConfigOverwrite.php
+++ b/lib/AppConfigOverwrite.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Guests;
 
 use OC\AppConfig;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Security\ICrypto;
 use Psr\Log\LoggerInterface;
@@ -20,11 +21,12 @@ class AppConfigOverwrite extends AppConfig {
 
 	public function __construct(
 		IDBConnection $connection,
+		IConfig $config,
 		LoggerInterface $logger,
 		ICrypto $crypto,
 		array $overWrite,
 	) {
-		parent::__construct($connection, $logger, $crypto);
+		parent::__construct($connection, $config, $logger, $crypto);
 		$this->overWrite = $overWrite;
 	}
 

--- a/lib/RestrictionManager.php
+++ b/lib/RestrictionManager.php
@@ -12,6 +12,7 @@ use OC\NavigationManager;
 use OCA\Files_External\Config\ExternalMountPoint;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\Mount\IMountPoint;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\INavigationManager;
 use OCP\IRequest;
@@ -83,6 +84,7 @@ class RestrictionManager {
 				$this->server->registerService(AppConfig::class, function () {
 					return new AppConfigOverwrite(
 						$this->server->get(IDBConnection::class),
+						$this->server->get(IConfig::class),
 						$this->server->get(LoggerInterface::class),
 						$this->server->get(ICrypto::class),
 						[


### PR DESCRIPTION
Ran into when logging into my local Nextcloud with a guest user:

`Could not boot testing: OCA\Guests\AppConfigOverwrite::__construct(): Argument #2 ($config) must be of type OCP\IConfig, OC\Log\PsrLoggerAdapter given, called in /var/www/html/apps-extra/guests/lib/RestrictionManager.php on line 84`

IConfig was added as a dependency for AppConfig with https://github.com/nextcloud/server/pull/53449. 