### PR TITLE
fix: prevent guests from changing their email address

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -15,6 +15,7 @@ use OCA\Guests\Listener\BeforeUserManagementRenderedListener;
 use OCA\Guests\Listener\LoadAdditionalScriptsListener;
 use OCA\Guests\Listener\ShareAutoAcceptListener;
 use OCA\Guests\Listener\TalkIntegrationListener;
+use OCA\Guests\Listener\UserChangedListener;
 use OCA\Guests\Notifications\Notifier;
 use OCA\Guests\RestrictionManager;
 use OCA\Guests\UserBackend;
@@ -31,6 +32,7 @@ use OCP\IServerContainer;
 use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Share\Events\ShareCreatedEvent;
+use OCP\User\Events\UserChangedEvent;
 use OCP\User\Events\UserFirstTimeLoggedInEvent;
 
 class Application extends App implements IBootstrap {
@@ -47,6 +49,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(ShareCreatedEvent::class, ShareAutoAcceptListener::class);
 		$context->registerEventListener(BeforeTemplateRenderedEvent::class, TalkIntegrationListener::class);
 		$context->registerEventListener(BeforeUserManagementRenderedEvent::class, BeforeUserManagementRenderedListener::class);
+		$context->registerEventListener(UserChangedEvent::class, UserChangedListener::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Listener/UserChangedListener.php
+++ b/lib/Listener/UserChangedListener.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Robin Appelman <robin@icewind.nl>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Guests\Listener;
+
+use OCA\Guests\GuestManager;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IUserSession;
+use OCP\User\Events\UserChangedEvent;
+
+/**
+ * Block guests from changing their email address
+ *
+ * @template-implements IEventListener<UserChangedEvent>
+ */
+class UserChangedListener implements IEventListener {
+	public function __construct(
+		private readonly IUserSession $userSession,
+		private readonly GuestManager $guestManager,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof UserChangedEvent) {
+			return;
+		}
+		if ($event->getFeature() !== 'eMailAddress') {
+			return;
+		}
+		$user = $event->getUser();
+		if ($this->userSession->getUser() !== $user) {
+			return;
+		}
+		if (!$this->guestManager->isGuest($user)) {
+			return;
+		}
+		if (strtolower($event->getValue()) === strtolower($user->getUID())) {
+			return;
+		}
+		$user->setSystemEMailAddress(strtolower($user->getUID()));
+		$event->stopPropagation();
+	}
+}


### PR DESCRIPTION
Since guest are identified by their email, allowing users to change them is probably a bad idea.