### PR TITLE
fix(DirMask): Allow creating path

### DIFF
--- a/lib/Storage/DirMask.php
+++ b/lib/Storage/DirMask.php
@@ -137,7 +137,8 @@ class DirMask extends PermissionsMask {
 	}
 
 	public function mkdir($path): bool {
-		if ($this->checkPath($path)) {
+		// Always allow creating the path of the dir mask.
+		if ($path !== $this->path && $this->checkPath($path)) {
 			return parent::mkdir($path);
 		} else {
 			return $this->storage->mkdir($path);


### PR DESCRIPTION
Needed for https://github.com/nextcloud/server/issues/31357.

The Guests app relied on base.php creating the `/<uid/files/` folder already, so the `mkdir` was never executed for the `$path` on the storage.

I tested this with the Talk integration tests as well and they now pass.