### PR TITLE
Load scripts if a user is logged in and is allowed invite guests

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -33,7 +33,6 @@ use OCP\Notification\IManager as INotificationManager;
 use OCP\Share\Events\ShareCreatedEvent;
 use OCP\User\Events\UserChangedEvent;
 use OCP\User\Events\UserFirstTimeLoggedInEvent;
-use OCP\Util;
 use Psr\Container\ContainerInterface;
 
 class Application extends App implements IBootstrap {
@@ -63,7 +62,6 @@ class Application extends App implements IBootstrap {
 		$this->setupGuestRestrictions($context->getAppContainer(), $context->getServerContainer());
 		$this->setupNotifications($context->getAppContainer());
 		$context->getAppContainer()->get(RestrictionManager::class)->lateSetupRestrictions();
-		Util::addScript('guests', 'guests-init');
 	}
 
 	private function setupGuestManagement(ContainerInterface $container, ContainerInterface $server): void {

--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -12,7 +12,6 @@ namespace OCA\Guests\Listener;
 
 use OCA\Guests\Config;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
-use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
@@ -23,7 +22,6 @@ use OCP\Util;
 class BeforeTemplateRenderedListener implements IEventListener {
 	public function __construct(
 		private Config $config,
-		private IInitialState $initialState,
 	) {
 	}
 
@@ -32,10 +30,17 @@ class BeforeTemplateRenderedListener implements IEventListener {
 			return;
 		}
 
-		$this->initialState->provideInitialState('canCreateGuests', $this->config->canCreateGuests());
+		if (!$event->isLoggedIn()) {
+			return;
+		}
+
+		if (!$this->config->canCreateGuests()) {
+			return;
+		}
+		Util::addScript('guests', 'guests-init');
 		Util::addScript('guests', 'guests-contactsmenu');
 
-		if (!$event->isLoggedIn() || $event->getResponse()->getTemplateName() !== 'index') {
+		if ($event->getResponse()->getTemplateName() !== 'index') {
 			return;
 		}
 

--- a/src/contactsmenu.ts
+++ b/src/contactsmenu.ts
@@ -5,15 +5,16 @@
 
 import AccountPlusOutlineSvg from '@mdi/svg/svg/account-plus-outline.svg?raw'
 import { t } from '@nextcloud/l10n'
+import { guestForm } from './init.ts'
 
 window.addEventListener('DOMContentLoaded', () => {
-	if (OC.ContactsMenu && OCA.Guests?.openGuestDialog) {
+	if (OC.ContactsMenu) {
 		OC.ContactsMenu.addAction({
 			id: 'guests_addGuestAction',
 			icon: AccountPlusOutlineSvg,
 			label: t('guests', 'Add guest'),
 			onClick: () => {
-				OCA.Guests.openGuestDialog('core')
+				guestForm.populate({ app: 'core' })
 			},
 		})
 	}

--- a/src/init.ts
+++ b/src/init.ts
@@ -8,8 +8,6 @@ import Vue from 'vue'
 import GuestForm from './views/GuestForm.vue'
 import Nextcloud from './mixins/Nextcloud.js'
 
-import { loadState } from '@nextcloud/initial-state'
-
 Vue.mixin(Nextcloud)
 
 if (!OCA.Guests) {
@@ -25,8 +23,8 @@ guestRoot.setAttribute('id', 'guest-root')
 document.body.appendChild(guestRoot)
 guestForm.$mount('#guest-root')
 
-if (loadState('guests', 'canCreateGuests', false)) {
-	OCA.Guests.openGuestDialog = (app: string, shareWith?: string) => guestForm.populate({ app }, shareWith)
+OCA.Guests.openGuestDialog = (app: string, shareWith?: string) => {
+	guestForm.populate({ app }, shareWith)
 }
 
 export { guestForm }

--- a/src/views/GuestForm.vue
+++ b/src/views/GuestForm.vue
@@ -21,7 +21,7 @@
 					<!-- Name -->
 					<div class="form-group">
 						<label class="form-label" for="app-guests-input-name">
-							{{ t('guests', 'Name') }}
+							{{ t('guests', 'Guest Name') }}
 						</label>
 						<input id="app-guests-input-name"
 							ref="name"
@@ -359,15 +359,6 @@ export default {
 		align-items: center;
 		span {
 			margin: 10px;
-		}
-		button {
-			height: 44px;
-			&.icon-loading-small {
-				padding-left: $modal-button-loading * 2;
-				&::after {
-					left: $modal-button-loading;
-				}
-			}
 		}
 	}
 }

--- a/tests/unit/Storage/DirMaskTest.php
+++ b/tests/unit/Storage/DirMaskTest.php
@@ -13,6 +13,9 @@ use OCA\Guests\Storage\DirMask;
 use OCP\Constants;
 use Test\TestCase;
 
+/**
+ * @group DB
+ */
 class DirMaskTest extends TestCase {
 	public function testReadonlyDir() {
 		$storage = new Temporary([]);


### PR DESCRIPTION
Scripts are loaded on the login page, which is unnecessary. This fixes the issue by only loading the scripts to add guests if a user is logged in and has the ability to invite guests.