### PR TITLE
fix: make compatible with admin delegation settings

### DIFF
--- a/lib/FilteredSettingsManager.php
+++ b/lib/FilteredSettingsManager.php
@@ -58,6 +58,10 @@ class FilteredSettingsManager implements IManager {
 		return $this->manager->getAdminSettings($section, $subAdminOnly);
 	}
 
+	public function getAdminDelegatedSettings(): array {
+		return $this->manager->getAdminDelegatedSettings();
+	}
+
 	public function getAllowedAdminSettings(string $section, IUser $user): array {
 		return $this->manager->getAllowedAdminSettings($section, $user);
 	}


### PR DESCRIPTION
Fallback of:
- https://github.com/nextcloud/server/pull/55261

Fixed:

PHP Fatal error:  Class OCA\Guests\FilteredSettingsManager contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (OCP\Settings\IManager::getAdminDelegatedSettings) in /var/www/html/apps-extra/guests/lib/FilteredSettingsManager.php on line 14