### PR TITLE
fix: add null check to guest to allow the repair step to continue

### DIFF
--- a/lib/Repair/ResetEmails.php
+++ b/lib/Repair/ResetEmails.php
@@ -39,6 +39,9 @@ class ResetEmails implements IRepairStep {
 
 		foreach ($this->guestManager->listGuests() as $guestId) {
 			$guest = $this->userManager->get($guestId);
+			if ($guest === null) {
+				continue;
+			}
 			$expectedEmail = $this->config->getUserValue($guestId, Application::APP_ID, 'email', strtolower($guestId));
 			if (strtolower($guest?->getSystemEMailAddress() ?? '') !== $expectedEmail) {
 				$this->config->setUserValue($guestId, 'guests', 'old_email', $guest?->getSystemEMailAddress() ?? '');


### PR DESCRIPTION
In few cases when guest is null this breaks the repair step and occ upgrade fails.