### PR TITLE
fix(invite): Add logging and fix decryption key in InviteService

### DIFF
--- a/lib/Listener/ShareCreatedListener.php
+++ b/lib/Listener/ShareCreatedListener.php
@@ -73,7 +73,6 @@ class ShareCreatedListener implements IEventListener {
 		}
 
 		$user = $this->userSession->getUser();
-		$this->userManager->get($shareWith);
 
 		if (!$user) {
 			throw new \Exception(

--- a/lib/Service/InviteService.php
+++ b/lib/Service/InviteService.php
@@ -12,6 +12,7 @@ namespace OCA\Guests\Service;
 use OCA\Guests\Mail;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IConfig;
+use OCP\IUserManager;
 use OCP\Security\ICrypto;
 use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
@@ -21,6 +22,7 @@ class InviteService {
 		private readonly LoggerInterface $logger,
 		private readonly IConfig $config,
 		private readonly ICrypto $crypto,
+		private readonly IUserManager $userManager,
 		private readonly Mail $mail,
 	) {
 	}
@@ -29,15 +31,23 @@ class InviteService {
 		$passwordToken = $this->config->getUserValue($guest, 'core', 'lostpassword', null);
 
 		if (!$passwordToken) {
+			$this->logger->warning('No password token found for guest "' . $guest . '", skipping invitation email');
 			return false;
 		}
 
 		try {
-			// user has not yet activated their account
-			$decryptedToken = $this->crypto->decrypt($passwordToken, strtolower($guest) . $this->config->getSystemValue('secret'));
+			$targetUser = $this->userManager->get($guest);
+			if ($targetUser === null) {
+				$this->logger->error('Guest user "' . $guest . '" not found');
+				return false;
+			}
+
+			$decryptedToken = $this->crypto->decrypt(
+				$passwordToken,
+				strtolower($targetUser->getEMailAddress()) . $this->config->getSystemValue('secret')
+			);
 			[, $token] = explode(':', $decryptedToken);
 			$lang = $this->config->getUserValue($guest, 'core', 'lang', '');
-			// send invitation
 			$this->mail->sendGuestInviteMail(
 				$userId,
 				$guest,


### PR DESCRIPTION
sendInvite() will silently return false with no logging when the lostpassword token is missing. Added warning/error logs and fixed decryption key to use getEMailAddress() matching GuestManager encryption.

Aslo removed dead code in Hooks.php.