### PR TITLE
fix(invite): Send invitation email independently of share creation

### DIFF
--- a/src/views/GuestForm.vue
+++ b/src/views/GuestForm.vue
@@ -72,6 +72,14 @@
 							{{ errors.groups }}
 						</NcNoteCard>
 					</div>
+
+					<!-- Send invite email -->
+					<div class="form-group">
+						<NcCheckboxRadioSwitch :checked.sync="sendInvite"
+							:disabled="loading">
+							{{ t('guests', 'Send invitation email') }}
+						</NcCheckboxRadioSwitch>
+					</div>
 				</div>
 
 				<!-- Footer -->
@@ -104,6 +112,7 @@ import axios from '@nextcloud/axios'
 import AccountPlus from 'vue-material-design-icons/AccountPlus.vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcModal from '@nextcloud/vue/components/NcModal'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 
 import { logger } from '../services/logger.ts'
@@ -117,6 +126,7 @@ export default {
 		GroupSelect,
 		LanguageSelect,
 		NcButton,
+		NcCheckboxRadioSwitch,
 		NcModal,
 		NcNoteCard,
 	},
@@ -129,6 +139,7 @@ export default {
 
 			isOpened: false,
 			loading: false,
+			sendInvite: true,
 
 			// guest data
 			guest: {
@@ -235,7 +246,7 @@ export default {
 					email: this.guest.email,
 					language: this.guest.language,
 					groups: this.guest.groups,
-					sendInvite: this.integrationApp !== 'files',
+					sendInvite: this.sendInvite,
 				})
 
 				if (this.integrationApp === 'files') {
@@ -301,6 +312,7 @@ export default {
 
 		resetForm() {
 			this.guest.fullName = this.guest.username = this.guest.email = ''
+			this.sendInvite = true
 		},
 
 		resetErrors() {


### PR DESCRIPTION
Previously, when inviting a guest from the files sharing dialog, the invitation email was suppressed (sendInvite was hardcoded to false) because the share notification email was expected to be sent on share save. This meant if the user didn't click "Save share", no email was ever sent. Added a checkbox to the guest form allowing users to control whether the invitation email is sent, defaulting to true.


| Before | After |
| ------  | ----- |
| <img width="638" height="634" alt="Screenshot 2026-03-19 at 8 08 18 PM" src="https://github.com/user-attachments/assets/b0098fac-72a7-4896-a905-f2bd36e58d74" /> | <img width="638" height="634" alt="Screenshot 2026-03-19 at 8 01 27 PM" src="https://github.com/user-attachments/assets/7069c20e-937f-4ed0-96ac-9957e375419c" /> |