### PR TITLE
fix: Allow guests to create public links

### DIFF
--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -52,6 +52,9 @@ class Hooks {
 		}
 
 		$shareWith = $share->getSharedWith();
+		if ($shareWith === null) {
+			return;
+		}
 
 		$isGuest = $this->guestManager->isGuest($shareWith);
 		if (!$isGuest) {


### PR DESCRIPTION
## Summary

When a guest user creates a public link, a fatal error occurs because the share hook attempts to process it as a user share, which it is not. This fix adds a check to ensure that shares without a recipient, such as public links, are correctly ignored by the guest invitation logic, resolving the error.

## Changes

- **lib/Hooks.php**: In `handlePostShare`, added a null check for `$shareWith` to prevent errors when processing shares that do not have a recipient, such as public link shares created by guests.

## Related Issue

Closes #1521

