### PR TITLE
fix: set displayname to email if no other is specified

### DIFF
--- a/lib/GuestManager.php
+++ b/lib/GuestManager.php
@@ -83,6 +83,8 @@ class GuestManager {
 
 		if ($displayName !== '') {
 			$user->setDisplayName($displayName);
+		} else {
+			$user->setDisplayName($email);
 		}
 
 		if ($language !== '') {


### PR DESCRIPTION
this ensures that hashed uid guests have a sensible display name