### PR TITLE
fix(vue3): restore global t/n helpers on app instances

### DIFF
--- a/src/components/GroupSelect.vue
+++ b/src/components/GroupSelect.vue
@@ -16,6 +16,7 @@
 </template>
 
 <script>
+import { t } from '@nextcloud/l10n'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
 
 export default {
@@ -51,6 +52,10 @@ export default {
 		selected() {
 			this.$emit('input', this.selected.map((group) => group.gid))
 		},
+	},
+
+	methods: {
+		t,
 	},
 }
 </script>

--- a/src/components/LanguageSelect.vue
+++ b/src/components/LanguageSelect.vue
@@ -16,6 +16,7 @@
 
 <script>
 import axios from '@nextcloud/axios'
+import { t } from '@nextcloud/l10n'
 import { generateOcsUrl } from '@nextcloud/router'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
 import logger from '../utils/logger.ts'
@@ -60,6 +61,8 @@ export default {
 	},
 
 	methods: {
+		t,
+
 		async loadLanguages() {
 			try {
 				const result = await axios.get(generateOcsUrl('apps/guests/api/v1/languages'))

--- a/src/views/GuestForm.vue
+++ b/src/views/GuestForm.vue
@@ -103,6 +103,7 @@
 import axios from '@nextcloud/axios'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
+import { t } from '@nextcloud/l10n'
 import { generateOcsUrl } from '@nextcloud/router'
 import { ShareType } from '@nextcloud/sharing'
 import NcButton from '@nextcloud/vue/components/NcButton'
@@ -186,6 +187,8 @@ export default {
 	},
 
 	methods: {
+		t,
+
 		populate(metaData, shareWith) {
 			if (
 				shareWith

--- a/src/views/GuestSettings.vue
+++ b/src/views/GuestSettings.vue
@@ -113,6 +113,7 @@
 <script>
 import axios from '@nextcloud/axios'
 import { showError } from '@nextcloud/dialogs'
+import { t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
 import { clearTimeout, setTimeout } from 'timers'
 import NcButton from '@nextcloud/vue/components/NcButton'
@@ -177,6 +178,8 @@ export default {
 	},
 
 	methods: {
+		t,
+
 		async loadConfig() {
 			const { data } = await axios.get(generateUrl('apps/guests/config'))
 			this.config = data


### PR DESCRIPTION
Resolves: #1547

## Summary

`GuestSettings`, `GuestForm`, `LanguageSelect` and `GroupSelect` call `t()` directly in their templates but neither import `t` nor expose it via `methods` after the Vue 3 migration removed the global `Nextcloud.js` mixin. The admin Guests page renders blank and the file Sharing "Invite guest" dropdown silently fails with `TypeError: e.t is not a function`.

Import `t` from `@nextcloud/l10n` in each affected SFC and register it on the component's `methods` so the template proxy can resolve it. Same per-component pattern already used in `GuestList.vue`, `GuestDetails.vue` and `TransferGuestDialog.vue`.

## Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation (manuals or wiki) has been updated or is not required
- [ ] Backports requested where applicable (ex: critical bugfixes)
- [x] Labels added where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] Milestone added for target branch/version (ex: 32.x for `stable32`)