### PR TITLE
chore: 4.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 4.7.1
+### Fixes
+* fix(vue3): expose t() in components broken by Vue 3 migration by @pringelmann in https://github.com/nextcloud/guests/pull/1551
+
+### Other
+* chore(dev-deps): Bump nextcloud/ocp package by @nextcloud-command in https://github.com/nextcloud/guests/pull/1550
+
 ## 4.5.1
 ### Changes
 * feat: add better description in settings by @skjnldsv in https://github.com/nextcloud/guests/pull/1390

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@
 Guests accounts can be created from the share menu by entering either the recipients email or name and choosing "create guest account", once the share is created the guest user will receive an email notification about the mail with a link to set their password.
 
 Guests users can only access files shared to them and cannot create any files outside of shares, additionally, the apps accessible to guest accounts are whitelisted.]]></description>
-	<version>4.7.0</version>
+	<version>4.7.1</version>
 	<licence>agpl</licence>
 	<author>Nextcloud</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "guests",
-  "version": "4.7.0-dev.0",
+  "version": "4.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "guests",
-      "version": "4.7.0-dev.0",
+      "version": "4.7.1",
       "license": "agpl",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guests",
   "description": "Create guest users which can only see files shared with them",
-  "version": "4.7.0-dev.0",
+  "version": "4.7.1",
   "type": "module",
   "author": "Robin Appelman <robin@icewind.nl>",
   "contributors": [


### PR DESCRIPTION
Release 4.7.1.

Hotfix for the Vue 3 migration regression in 4.7.0 (#1547):

- #1551 fix(vue3): expose t() in components broken by Vue 3 migration
- #1550 chore(dev-deps): Bump nextcloud/ocp package