### PR TITLE
fix(invite): send welcome email when creating guest from share dialog

### DIFF
--- a/src/views/GuestForm.vue
+++ b/src/views/GuestForm.vue
@@ -238,7 +238,6 @@ export default {
 					email: this.guest.email,
 					language: this.guest.language,
 					groups: this.guest.groups,
-					sendInvite: this.integrationApp !== 'files',
 				})
 
 				if (this.integrationApp === 'files') {


### PR DESCRIPTION
## Summary

`GuestForm` sends `sendInvite: false` when opened from the Files share dialog. Intent (cc @leftybournes, this was set up in 0c42d5c) was to dedupe with `ShareCreatedListener`, which sends its own "X shared a file with you" mail after the share lands. Problem: the share only lands when the user clicks confirm on the `SharingDetailsTab` that opens *after* the guest form closes. If they close the sidebar or navigate away, the guest exists with no welcome mail and no password-reset link, so they can't log in at all.

Dropping the flag entirely. Backend defaults to `sendInvite: true`, so the welcome fires at creation regardless of integration. If a share follows, the listener still sends the contextualised share mail on top.

Both mails carry the same `lostpassword` token URL, so the duplicate Activate-account buttons land on the same setup flow. Net cost: two mails in the happy path. Net benefit: no more stranded guest accounts.

@leftybournes - flagging in case I'm missing context on the original dedup decision. The two mails are textually different so this isn't a literal duplicate, but happy to revisit if there was a UX concern I'm not seeing.

## Backport

stable4.7, stable4.6, stable4.5