### PR TITLE
fix(InviteService): use user id to fetch user config

### DIFF
--- a/lib/Service/InviteService.php
+++ b/lib/Service/InviteService.php
@@ -28,7 +28,7 @@ class InviteService {
 	}
 
 	public function sendInvite(string $userId, string $guest, ?IShare $share = null): bool {
-		$passwordToken = $this->config->getUserValue($guest, 'core', 'lostpassword', null);
+		$passwordToken = $this->config->getUserValue($userId, 'core', 'lostpassword');
 
 		if (!$passwordToken) {
 			$this->logger->warning('No password token found for guest "' . $guest . '", skipping invitation email');


### PR DESCRIPTION
- resolves https://github.com/nextcloud/guests/issues/1555

The user config is saved using the userId not the "shareWith" entry. So we need to fetch it with the userId.