### PR TITLE
fix(invite): guard against JS double-mount

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -12,14 +12,22 @@ if (!OCA.Guests) {
 	OCA.Guests = {}
 }
 
-// Create mount point for the guest form dialog
-const guestRoot = document.createElement('div')
-guestRoot.setAttribute('id', 'guest-root')
-document.body.appendChild(guestRoot)
+// NC appends a `?v=...` cache-buster to the script-tag URL but the
+// bundled `import` from main.ts doesn't, so this module loads twice.
+// Reuse the first mount instead of creating a second Vue app. See #1555.
+let guestForm: InstanceType<typeof GuestForm>
+if (OCA.Guests._guestForm) {
+	guestForm = OCA.Guests._guestForm
+} else {
+	const guestRoot = document.createElement('div')
+	guestRoot.setAttribute('id', 'guest-root')
+	document.body.appendChild(guestRoot)
 
-// Initialize the guest form dialog and expose it
-const guestForm = createApp(GuestForm)
-	.mount('#guest-root') as InstanceType<typeof GuestForm>
+	guestForm = createApp(GuestForm)
+		.mount('#guest-root') as InstanceType<typeof GuestForm>
+
+	OCA.Guests._guestForm = guestForm
+}
 
 OCA.Guests.openGuestDialog = (app: string, shareWith?: string) => {
 	guestForm.populate({ app }, shareWith)


### PR DESCRIPTION
## Summary

Fixes #1555. Modal not opening when clicking "Invite guest" in the share dialog on production NC 32.x.

## Root cause

`guests-init.mjs` was evaluating twice in production. NC's `Util::addScript` appends a `?v=<hash>` cache-buster to the script-tag URL, but the bundled `import` inside `guests-main.mjs` uses the bare relative path. Different URLs, the browser keys ES modules by URL, so the file runs twice and `createApp(GuestForm).mount('#guest-root')` happens twice.

The visible Vue instance is the last-evaluated one. `OCA.Guests.openGuestDialog` is reassigned during both evaluations and ends up bound to that visible instance, so Talk and contacts integrations work fine. But `main.ts` does `import { guestForm } from './init.ts'`, which resolves to the bare-path module record, i.e. the orphaned first instance. The share-dialog handler then writes `isOpened = true` on a detached vnode and nothing visible happens.

Didn't reproduce on docker-dev because `TemplateLayout::getVersionHashSuffix()` returns an empty string when `debug => true` (which docker-dev sets by default), so both URLs match and the module loads once. Reproduces on the official `nextcloud:32.0.9` Docker image and every real production install.

## Fix

Make `init.ts` idempotent. The first evaluation creates the Vue app and stashes it on `OCA.Guests._guestForm`. The second evaluation reuses it instead of mounting a second app on `#guest-root`. `openGuestDialog` is assigned once after the if/else so its presence doesn't depend on which branch ran. No behavioral change for callers.

## Related

The server-side fix for this exact bug already exists in NC33+: [nextcloud/server#56941](https://github.com/nextcloud/server/pull/56941) added `emit_import_map()`, which emits an ES module importmap aliasing the bare path to the cache-busted URL. Single module record, double-mount becomes impossible. Backported to `stable33` and `stable34`, not `stable32`. Asking for that backport separately. Other community apps with multi-entry bundles probably hit the same latent issue on NC32.

## Test plan

- [x] Reproduces on `nextcloud:32.0.9` with guests v4.7.4 from app store, matches #1555 stack trace
- [x] Patch applied: modal opens correctly via share dialog

## Backport

`stable-4.7`
