### PR TITLE
fix(settings): use @update:modelValue so admin switches save again

### DIFF
--- a/src/views/GuestSettings.vue
+++ b/src/views/GuestSettings.vue
@@ -38,21 +38,21 @@
 				<NcCheckboxRadioSwitch
 					v-model="config.allowExternalStorage"
 					type="switch"
-					@update:checked="saveConfig">
+					@update:modelValue="saveConfig">
 					{{ t('guests', 'Guest accounts can access mounted external storages') }}
 				</NcCheckboxRadioSwitch>
 
 				<NcCheckboxRadioSwitch
 					v-model="config.useHashedEmailAsUserID"
 					type="switch"
-					@update:checked="saveConfig">
+					@update:modelValue="saveConfig">
 					{{ t('guests', 'Use a hash of the email as user ID for improved privacy') }}
 				</NcCheckboxRadioSwitch>
 
 				<NcCheckboxRadioSwitch
 					v-model="config.hideUsers"
 					type="switch"
-					@update:checked="saveConfig">
+					@update:modelValue="saveConfig">
 					{{ t('guests', 'Hide other accounts from guests') }}
 				</NcCheckboxRadioSwitch>
 
@@ -64,7 +64,7 @@
 				<NcCheckboxRadioSwitch
 					:modelValue="config.createRestrictedToGroup.length > 0"
 					type="switch"
-					@update:checked="onGroupRestrictToggle">
+					@update:modelValue="onGroupRestrictToggle">
 					{{ t('guests', 'Limit guest account creation to the following groups only') }}
 				</NcCheckboxRadioSwitch>
 
@@ -80,7 +80,7 @@
 				<NcCheckboxRadioSwitch
 					v-model="config.useWhitelist"
 					type="switch"
-					@update:checked="saveConfig">
+					@update:modelValue="saveConfig">
 					{{ t('guests', 'Limit guest access to an app\'s allowlist') }}
 				</NcCheckboxRadioSwitch>
 


### PR DESCRIPTION
### Summary
On the Guests admin settings page none of the switches persisted: toggling any switch did nothing on save and it reverted after a reload, and the "Limit guest account creation to the following groups only" switch could not be toggled at all. No `PUT /apps/guests/config` was ever sent.

### Root cause
`src/views/GuestSettings.vue` wires the save handler to `@update:checked`:

```vue
<NcCheckboxRadioSwitch
    v-model="config.allowExternalStorage"
    type="switch"
    @update:checked="saveConfig">
```

`NcCheckboxRadioSwitch` in `@nextcloud/vue` 9.x emits `update:modelValue`, not `update:checked` (the bundled component declares `emits: ["update:modelValue"]`). So `saveConfig()` was never called. `v-model` still updated the local state, so the switch flipped visually while nothing was persisted. The group switch additionally used a one-way `:modelValue` together with the same dead event, so its state never changed at all.

### Regression
This worked before the Vue 3 migration. It broke in `0ed6e335` ("chore: migrate to vue 3" #1323 ), which bumped `@nextcloud/vue` from `^8.33.0` to `^9.6.0`. That commit correctly converted `:checked.sync` to `v-model` but left the separate `@update:checked="saveConfig"` listeners unchanged. On `@nextcloud/vue` 8.x the component emitted `update:checked`, so both the binding and the save handler fired; on 9.x only `update:modelValue` is emitted. The same commit already used the correct event for `NcSettingsSelectGroup` (`@update:modelValue="onSelectGroups"`), so only the `NcCheckboxRadioSwitch` listeners were missed.

Affected: `4.7.0` through `4.7.5` and current `main`. Not affected: `4.6.x` and earlier (Vue 2 / `@nextcloud/vue` 8). A backport to the `4.7` line is therefore needed in addition to `main`.

### Fix
Replace `@update:checked` with `@update:modelValue` on all five `NcCheckboxRadioSwitch` switches (the four `saveConfig` switches and the group-restriction toggle).

### Testing
Built against the released `v4.7.5` and deployed to a live instance:
- Toggling any switch now persists and survives a reload.
- A `PUT /apps/guests/config` is now sent on toggle (previously only `GET` appeared in the access log).
- The "Your settings have been updated" toast shows.
- The group-restriction switch can now be toggled.

Fixes #995

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
