### PR TITLE
fix: Add missing index on email the guest_users table

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@
 Guests accounts can be created from the share menu by entering either the recipients email or name and choosing "create guest account", once the share is created the guest user will receive an email notification about the mail with a link to set their password.
 
 Guests users can only access files shared to them and cannot create any files outside of shares, additionally, the apps accessible to guest accounts are whitelisted.]]></description>
-	<version>4.8.0-dev.0</version>
+	<version>4.8.0-dev.1</version>
 	<licence>agpl</licence>
 	<author>Nextcloud</author>
 	<types>

--- a/lib/Migration/Version4008Date20260609101600.php
+++ b/lib/Migration/Version4008Date20260609101600.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Guests\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\Attributes\AddIndex;
+use OCP\Migration\Attributes\IndexType;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+#[AddIndex(table: 'guests_users', type: IndexType::INDEX, description: 'Add missing index')]
+class Version4008Date20260609101600 extends SimpleMigrationStep {
+	public function __construct(
+		protected IDBConnection $db,
+	) {
+	}
+
+	/**
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('guests_users');
+		if ($table->hasIndex('guests_users_email')) {
+			return null;
+		}
+
+		$table->addIndex(['email'], 'guests_users_email');
+		return $schema;
+	}
+}


### PR DESCRIPTION
The column was added on May 1 2025 with the Version4002 migration, later in 2026 the index was added to the existing migration, so there was some releases in the middle with users potentially missing the index.

Add a new migration which explicitely add the index if missing.

See https://github.com/nextcloud/guests/pull/1542 

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
