### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/vendor-bin/nextcloud-ocp/composer.lock
+++ b/vendor-bin/nextcloud-ocp/composer.lock
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "ef43111aa5096fc2818ff79631cd0801ec4e3cc4"
+                "reference": "c4ecbe0efea507588f135f2215de92ec098c3956"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/ef43111aa5096fc2818ff79631cd0801ec4e3cc4",
-                "reference": "ef43111aa5096fc2818ff79631cd0801ec4e3cc4",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/c4ecbe0efea507588f135f2215de92ec098c3956",
+                "reference": "c4ecbe0efea507588f135f2215de92ec098c3956",
                 "shasum": ""
             },
             "require": {
@@ -53,7 +53,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable32"
             },
-            "time": "2026-06-03T02:42:41+00:00"
+            "time": "2026-06-18T02:36:01+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency