### PR TITLE
feat(settings): add a default quota selector for new guest accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The app is published in the [app store](https://apps.nextcloud.com/apps/guests).
 
 ## Development
 
-Development is ongoing. A [CHANGELOG](https://github.com/nextcloud/guests/blob/master/CHANGELOG.md) covers the highlights. [New releases are also published](https://github.com/nextcloud-releases/guests/releases) on GitHub.
+Development is ongoing. A [CHANGELOG](https://github.com/nextcloud/guests/blob/main/CHANGELOG.md) covers the highlights. [New releases are also published](https://github.com/nextcloud-releases/guests/releases) on GitHub.
 
 ## Usage
 
@@ -43,12 +43,12 @@ Optionally, when creating a guest the following values may also be specified:
 
 Admins/Group admins also may:
 
-* specify the group(s) to put the guest user in (see [Guest specific behavior and configuration](https://github.com/nextcloud/guests/blob/master/README.md#guest-specific-behavior-and-configuration) for details).
+* specify the group(s) to put the guest user in (see [Guest specific behavior and configuration](https://github.com/nextcloud/guests/blob/main/README.md#guest-specific-behavior-and-configuration) for details).
 
 ![image](https://github.com/nextcloud/guests/assets/1731941/68edbd4f-fedc-45f0-8241-2e1cd12d04de)
 
 > [!WARNING]
-> While it is easy to create a new Guest, it's important to understand the default behavior and how guests interact with other features in Nextcloud. See [Guest specific behavior and configuration](https://github.com/nextcloud/guests/blob/master/README.md#guest-specific-behavior-and-configuration) for details.
+> While it is easy to create a new Guest, it's important to understand the default behavior and how guests interact with other features in Nextcloud. See [Guest specific behavior and configuration](https://github.com/nextcloud/guests/blob/main/README.md#guest-specific-behavior-and-configuration) for details.
 
 ### Deleting a guest
 
@@ -149,6 +149,24 @@ By default, guests will not be able to list other users in the system, but if a 
 to list users within that group (and, for example, share files with those users).
 
 As a result, guests will be able to see each other as they are part of the same `guest` group. To prevent that behavior, you can add the `guest` group to the "Exclude groups from sharing" settings. You can find more information in [our documentation about sharing](https://docs.nextcloud.com/server/21/admin_manual/configuration_files/file_sharing_configuration.html).
+
+### Default quota for new guests
+
+New guest accounts are created with a default storage quota. This default comes from the **Quick presets** configuration (*Administration → Quick presets*), where it is listed as *"set default disk quota assigned to guest account at its creation"* (`guest_quota`). Its value depends on the selected preset: the **Default** preset uses `0 B`, while organization or family presets use a non-zero quota such as `1 GB` or `10 GB`. As a result, on many instances guests no longer receive `0 B` automatically.
+
+Administrators can review and override this default under **Administration settings → Guests → "Default quota for new guest accounts"**: pick a preset (the *Default* entry shows the current preset value), *Unlimited*, or enter a custom size such as `500 MB`.
+
+It can also be set on the command line:
+
+```
+occ config:app:set guests guest_quota --value "500 MB"
+```
+
+Remove the override to fall back to the Quick presets default again:
+
+```
+occ config:app:delete guests guest_quota
+```
 
 ### Converting guest users to full users
 

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Guests;
 
+use OCA\Guests\AppInfo\Application;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\Group\ISubAdmin;
 use OCP\IAppConfig as IGlobalAppConfig;
@@ -49,6 +50,42 @@ class Config {
 
 	public function setHideOtherUsers(bool $hide): void {
 		$this->appConfig->setAppValueBool(ConfigLexicon::HIDE_OTHER_ACCOUNTS, $hide);
+	}
+
+	/**
+	 * Currently configured default quota for new guest accounts. Returns the
+	 * explicit override if one is set, otherwise the preset-derived default.
+	 */
+	public function getGuestQuota(): string {
+		return $this->appConfig->getAppValueString(ConfigLexicon::GUEST_DISK_QUOTA);
+	}
+
+	/**
+	 * Whether an explicit default quota is stored, as opposed to falling back
+	 * to the preset-derived default from the config lexicon.
+	 */
+	public function hasGuestQuotaOverride(): bool {
+		return $this->globalAppConfig->hasKey(Application::APP_ID, ConfigLexicon::GUEST_DISK_QUOTA);
+	}
+
+	/**
+	 * The preset-derived default quota, regardless of any override. This is the
+	 * value the instance's configuration preset assigns to guests.
+	 */
+	public function getGuestQuotaDefault(): string {
+		return (string)($this->globalAppConfig->getKeyDetails(Application::APP_ID, ConfigLexicon::GUEST_DISK_QUOTA)['default'] ?? '0 B');
+	}
+
+	/**
+	 * Store the default guest quota. An empty value or 'default' removes the
+	 * override so the preset-derived default applies again.
+	 */
+	public function setGuestQuota(?string $quota): void {
+		if ($quota === null || $quota === '' || $quota === 'default') {
+			$this->appConfig->deleteAppValue(ConfigLexicon::GUEST_DISK_QUOTA);
+			return;
+		}
+		$this->appConfig->setAppValueString(ConfigLexicon::GUEST_DISK_QUOTA, $quota);
 	}
 
 	public function getHome(string $uid): string {

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -18,6 +18,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\IRequest;
+use OCP\Util;
 
 /**
  * Class SettingsController is used to handle configuration changes on the
@@ -55,13 +56,15 @@ class SettingsController extends Controller {
 			'whiteListableApps' => $this->appWhitelist->getWhitelistAbleApps(),
 			'sharingRestrictedToGroup' => $this->config->isSharingRestrictedToGroup(),
 			'createRestrictedToGroup' => $this->config->getCreateRestrictedToGroup(),
+			'guestQuota' => $this->config->hasGuestQuotaOverride() ? $this->config->getGuestQuota() : 'default',
+			'guestQuotaDefault' => $this->config->getGuestQuotaDefault(),
 		]);
 	}
 
 	/**
 	 * @param list<string> $whitelist
 	 */
-	public function setConfig(bool $useWhitelist, array $whitelist, bool $allowExternalStorage, bool $useHashedEmailAsUserID, bool $hideUsers, array $createRestrictedToGroup): DataResponse {
+	public function setConfig(bool $useWhitelist, array $whitelist, bool $allowExternalStorage, bool $useHashedEmailAsUserID, bool $hideUsers, array $createRestrictedToGroup, string $guestQuota = 'default'): DataResponse {
 		$newWhitelist = [];
 		foreach ($whitelist as $app) {
 			$newWhitelist[] = trim((string)$app);
@@ -73,8 +76,24 @@ class SettingsController extends Controller {
 		$this->config->setUseHashedEmailAsUserID($useHashedEmailAsUserID);
 		$this->config->setHideOtherUsers($hideUsers);
 		$this->config->setCreateRestrictedToGroup($createRestrictedToGroup);
+		if ($this->isValidQuota($guestQuota)) {
+			$this->config->setGuestQuota($guestQuota);
+		}
 
 		return new DataResponse();
+	}
+
+	/**
+	 * A quota value is acceptable if it is the "default" sentinel, "none"
+	 * (unlimited) or a human-readable size such as "500 MB".
+	 */
+	private function isValidQuota(string $quota): bool {
+		if ($quota === 'default' || $quota === 'none') {
+			return true;
+		}
+		// Require an explicit unit so the stored value is unambiguous (e.g. "500 MB").
+		return preg_match('/^\d+(\.\d+)?\s*[KMGTP]?B$/i', trim($quota)) === 1
+			&& Util::computerFileSize($quota) !== false;
 	}
 
 	/**

--- a/src/views/GuestSettings.vue
+++ b/src/views/GuestSettings.vue
@@ -128,6 +128,22 @@
 						{{ t('guests', 'Reset allowlist') }}
 					</NcButton>
 				</div>
+
+				<!-- Default quota for new guest accounts -->
+				<div class="guest-quota">
+					<label :for="quotaInputId" class="guest-quota__label">
+						{{ t('guests', 'Default quota for new guest accounts') }}
+					</label>
+					<NcSelect
+						v-model="quotaModel"
+						:inputId="quotaInputId"
+						class="guest-quota__select"
+						:options="quotaOptions"
+						:clearable="false"
+						:filterable="false"
+						label="label"
+						@search="onQuotaSearch" />
+				</div>
 			</div>
 			<div v-if="!loaded">
 				<div class="loading" />
@@ -180,6 +196,8 @@ export default {
 			savingTimeout: null,
 			editingAllowlist: false,
 			whitelistDraft: [],
+			quotaInputId: 'guests-default-quota',
+			quotaSearch: '',
 			config: {
 				useWhitelist: false,
 				allowExternalStorage: false,
@@ -189,6 +207,8 @@ export default {
 				whiteListableApps: [],
 				sharingRestrictedToGroup: false,
 				createRestrictedToGroup: [],
+				guestQuota: 'default',
+				guestQuotaDefault: '0 B',
 			},
 		}
 	},
@@ -201,6 +221,54 @@ export default {
 			return (this.config.whitelist ?? [])
 				.map((app) => (typeof app === 'string' ? app : (app.label ?? app.id ?? app.name ?? String(app))))
 				.filter(Boolean)
+		},
+
+		baseQuotaOptions() {
+			return [
+				{ id: 'default', label: t('guests', 'Default quota ({size})', { size: this.config.guestQuotaDefault || '0 B' }) },
+				{ id: 'none', label: t('guests', 'Unlimited') },
+				{ id: '1 GB', label: '1 GB' },
+				{ id: '5 GB', label: '5 GB' },
+				{ id: '10 GB', label: '10 GB' },
+			]
+		},
+
+		// When a bare number is typed, offer it with selectable units (KB/MB/GB)
+		// instead of silently assuming bytes. A partially typed unit narrows the
+		// suggestions (e.g. "500 m" → "500 MB").
+		quotaOptions() {
+			const search = (this.quotaSearch || '').trim()
+			const parts = search.match(/^(\d+(?:\.\d+)?)\s*([a-z]*)$/i)
+			if (parts) {
+				const value = parts[1]
+				const typedUnit = parts[2].toLowerCase()
+				const units = ['KB', 'MB', 'GB']
+				const matching = typedUnit
+					? units.filter((unit) => unit.toLowerCase().startsWith(typedUnit))
+					: units
+				return (matching.length ? matching : units)
+					.map((unit) => ({ id: `${value} ${unit}`, label: `${value} ${unit}` }))
+			}
+			return this.baseQuotaOptions
+		},
+
+		quotaModel: {
+			get() {
+				const current = this.config.guestQuota
+				return this.baseQuotaOptions.find((option) => option.id === current)
+					?? { id: current, label: current }
+			},
+
+			set(option) {
+				const value = (option && typeof option === 'object') ? option.id : option
+				if (!this.isValidQuota(value)) {
+					showError(t('guests', 'Please enter a quota with a unit, for example "500 MB" or "2 GB"'))
+					return
+				}
+				this.config.guestQuota = value
+				this.quotaSearch = ''
+				this.saveConfig()
+			},
 		},
 
 		statusText() {
@@ -235,6 +303,18 @@ export default {
 			this.config.whitelist = [...this.whitelistDraft]
 			this.editingAllowlist = false
 			this.saveConfig()
+		},
+
+		onQuotaSearch(query) {
+			this.quotaSearch = query
+		},
+
+		isValidQuota(value) {
+			// A unit is required so the stored value is unambiguous; a bare
+			// number like "500" is rejected (it would mean 500 bytes).
+			return value === 'default'
+				|| value === 'none'
+				|| /^\d+(\.\d+)?\s*(b|kb|mb|gb|tb|pb)$/i.test(String(value).trim())
 		},
 
 		async loadConfig() {
@@ -370,6 +450,16 @@ export default {
 
 	.reset-button {
 		margin-top: 1rem;
+	}
+}
+
+.guest-quota {
+	margin-top: 1.5rem;
+	max-width: 400px;
+
+	&__label {
+		display: block;
+		margin-bottom: 4px;
 	}
 }
 

--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -253,4 +253,52 @@ class ConfigTest extends TestCase {
 
 		$this->guestConfig->setCreateRestrictedToGroup(['group1', 'group2']);
 	}
+
+	public function testGetGuestQuota(): void {
+		$this->appConfig->method('getAppValueString')
+			->with('guest_quota')
+			->willReturn('5 GB');
+
+		$this->assertEquals('5 GB', $this->guestConfig->getGuestQuota());
+	}
+
+	public function testHasGuestQuotaOverride(): void {
+		$this->globalAppConfig->method('hasKey')
+			->with('guests', 'guest_quota')
+			->willReturn(true);
+
+		$this->assertTrue($this->guestConfig->hasGuestQuotaOverride());
+	}
+
+	public function testGetGuestQuotaDefault(): void {
+		$this->globalAppConfig->method('getKeyDetails')
+			->with('guests', 'guest_quota')
+			->willReturn(['app' => 'guests', 'key' => 'guest_quota', 'default' => '1 GB']);
+
+		$this->assertEquals('1 GB', $this->guestConfig->getGuestQuotaDefault());
+	}
+
+	public function testGetGuestQuotaDefaultFallsBackWhenNoLexiconDefault(): void {
+		$this->globalAppConfig->method('getKeyDetails')
+			->with('guests', 'guest_quota')
+			->willReturn(['app' => 'guests', 'key' => 'guest_quota']);
+
+		$this->assertEquals('0 B', $this->guestConfig->getGuestQuotaDefault());
+	}
+
+	public function testSetGuestQuotaValue(): void {
+		$this->appConfig->expects($this->once())
+			->method('setAppValueString')
+			->with('guest_quota', '500 MB');
+
+		$this->guestConfig->setGuestQuota('500 MB');
+	}
+
+	public function testSetGuestQuotaDefaultRemovesOverride(): void {
+		$this->appConfig->expects($this->once())
+			->method('deleteAppValue')
+			->with('guest_quota');
+
+		$this->guestConfig->setGuestQuota('default');
+	}
 }

--- a/tests/unit/Controller/SettingsControllerTest.php
+++ b/tests/unit/Controller/SettingsControllerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Guests\Test\Unit\Controller;
+
+use OCA\Guests\AppWhitelist;
+use OCA\Guests\Config;
+use OCA\Guests\Controller\SettingsController;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class SettingsControllerTest extends TestCase {
+	private IRequest&MockObject $request;
+	private Config&MockObject $config;
+	private IAppConfig&MockObject $appConfig;
+	private AppWhitelist&MockObject $appWhitelist;
+	private SettingsController $controller;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->config = $this->createMock(Config::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->appWhitelist = $this->createMock(AppWhitelist::class);
+
+		$this->controller = new SettingsController(
+			$this->request,
+			$this->config,
+			$this->appConfig,
+			$this->appWhitelist,
+		);
+	}
+
+	private function setConfigWithQuota(string $quota): void {
+		$this->controller->setConfig(false, [], false, true, false, [], $quota);
+	}
+
+	public function testSetConfigStoresValidQuota(): void {
+		$this->config->expects($this->once())
+			->method('setGuestQuota')
+			->with('500 MB');
+
+		$this->setConfigWithQuota('500 MB');
+	}
+
+	public function testSetConfigStoresDefaultSentinel(): void {
+		$this->config->expects($this->once())
+			->method('setGuestQuota')
+			->with('default');
+
+		$this->setConfigWithQuota('default');
+	}
+
+	public function testSetConfigStoresUnlimited(): void {
+		$this->config->expects($this->once())
+			->method('setGuestQuota')
+			->with('none');
+
+		$this->setConfigWithQuota('none');
+	}
+
+	public function testSetConfigIgnoresQuotaWithoutUnit(): void {
+		$this->config->expects($this->never())
+			->method('setGuestQuota');
+
+		$this->setConfigWithQuota('500');
+	}
+
+	public function testSetConfigIgnoresGarbageQuota(): void {
+		$this->config->expects($this->never())
+			->method('setGuestQuota');
+
+		$this->setConfigWithQuota('not a size');
+	}
+}


### PR DESCRIPTION
### Summary

Adds a default quota for new guest accounts, configurable from the Guests tab.

This is the second part of #1602, which was split in two: the allowlist regression fix landed separately as #1616, and this PR carries the quota feature.

### Feature

- Quota selector on the Guests tab, mirroring the Accounts quota field: **Default (…)**, **Unlimited**, **1 GB / 5 GB / 10 GB**, or a typed custom value. Typing a number offers it with selectable units (e.g. `500` becomes `500 KB / 500 MB / 500 GB`); a unit is required so the stored value is unambiguous.
- The **Default** option shows the actual preset-derived value (e.g. "Default (1 GB)"), read from the config lexicon via `IAppConfig::getKeyDetails()`. Selecting it removes the override so the preset default applies again, and the label follows the active Quick preset even while an override is set.

Backend: `Config` gains `getGuestQuota()`, `hasGuestQuotaOverride()`, `getGuestQuotaDefault()` and `setGuestQuota()`; `SettingsController::getConfig()` returns `guestQuota` (the `default` sentinel when no override is stored) and `guestQuotaDefault`, and `setConfig()` accepts and validates `guestQuota`. `GuestManager` already applies `guest_quota` on guest creation, so guest behaviour is unchanged.

### Docs

Documents the default guest quota in the README and corrects three links that still pointed to the removed `master` branch.

Closes #1601

### Testing

- Pick a preset, Unlimited, or a typed size, reload: the value persists.
- "Default (…)" removes the override; a bare number without a unit is rejected.
- Switching the Quick preset updates the "Default (…)" label, including when an override is currently stored.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI
Assisted-by: ClaudeCode:claude-opus-4-8

---
### Screenshots:

<img width="1233" height="1205" alt="image" src="https://github.com/user-attachments/assets/aeb07b2c-c9f1-402c-9510-f78dbe493f09" />

---
<img width="348" height="330" alt="image" src="https://github.com/user-attachments/assets/77ba8182-fe26-4b71-b5e8-f97a16f00078" />

---
<img width="347" height="240" alt="image" src="https://github.com/user-attachments/assets/f133fc49-2972-4c58-8160-ceae992e759e" />
