### PR TITLE
feat: convert regular accounts to guests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Guests may be deleted in the same way you would remove (or disable) regular user
 The command `occ guests:add` can be used to create guest users on the command-line.
 
 ```
-php occ guests:add [--generate-password] [--password-from-env] [--display-name [DISPLAY-NAME]] [--language [LANGUAGE]] [--] <created-by> <email>
+php occ guests:add [--uid [UID]] [--generate-password] [--password-from-env] [--display-name [DISPLAY-NAME]] [--language [LANGUAGE]] [--] <created-by> <email>
 ```
 
 For example:
@@ -69,6 +69,14 @@ OC_PASS=somepassword php occ guests:add --password-from-env --display-name "Max 
 ```
 
 The user will then be able to login with "maxmustermann@example.com" using the given password.
+
+By default the guest's login name (user ID) is derived from the email address, or a hash of it when the *"Use a hash of the email as user ID for improved privacy"* setting is enabled. To give the guest a free-form login name instead, pass `--uid`:
+
+```bash
+OC_PASS=somepassword php occ guests:add --password-from-env --uid maxm admin maxmustermann@example.com
+```
+
+The guest can then log in with "maxm".
 
 When using `--generate-password` instead of giving a password, a random password will be generated. The guest user should then use the "forgot password" link to reset it.
 
@@ -168,6 +176,20 @@ Remove the override to fall back to the Quick presets default again:
 occ config:app:delete guests guest_quota
 ```
 
+### Converting accounts to guests
+
+An administrator can convert a regular account into a guest account. In *Administration settings → Users*, open the account's `…` menu and choose **Convert to guest account**. The account keeps its login name and password but becomes a limited guest, restricted to the apps allowed for guests, and receives the [default guest quota](#default-quota-for-new-guests). The conversion cannot be undone automatically.
+
+This is only possible for accounts that
+
+* use the database backend,
+* are not already a guest, and
+* have **never logged in**.
+
+A typical use case is self-registration through the [registration](https://apps.nextcloud.com/apps/registration) app with *"Require administrator approval"* enabled: those accounts are created disabled and never logged in, so instead of enabling them an administrator can downgrade them to guests. Once such an account has logged in, conversion is no longer possible.
+
+If you would rather registered users keep their email address as login name, enable *"Force email as login name"* in the registration app settings.
+
 ### Converting guest users to full users
 
 Guest users can be automatically converted into full users (provided by any other user back end like SAML, LDAP, OAuth, database...) on their **first** login. When this happens they will retain their shares.
@@ -185,4 +207,4 @@ By default the old (guest) account will be disabled after successful conversion.
 - Enhancement ideas: https://github.com/nextcloud/guests/issues
 - Pull requests: https://github.com/nextcloud/guests/pulls
 - Troubleshooting assistance: https://help.nextcloud.com
-- Code: https://github.com/nextcloud/guests/tree/master
+- Code: https://github.com/nextcloud/guests/tree/main

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -51,6 +51,11 @@ return [
 			'verb' => 'POST',
 		],
 		[
+			'name' => 'users#convert',
+			'url' => '/api/v1/convert',
+			'verb' => 'POST',
+		],
+		[
 			'name' => 'API#languages',
 			'url' => '/api/v1/languages',
 			'verb' => 'GET'

--- a/lib/Command/AddCommand.php
+++ b/lib/Command/AddCommand.php
@@ -49,6 +49,12 @@ class AddCommand extends Command {
 				'Email address'
 			)
 			->addOption(
+				'uid',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'Login name (user ID) for the guest. If omitted, the email address is used (hashed when the privacy setting is enabled).'
+			)
+			->addOption(
 				'generate-password',
 				null,
 				InputOption::VALUE_NONE,
@@ -86,11 +92,15 @@ class AddCommand extends Command {
 		}
 
 		$email = $input->getArgument('email');
-		if ($this->config->useHashedEmailAsUserID()) {
-			$email = strtolower($email);
-			$uid = hash('sha256', $email);
-		} else {
-			$uid = $email;
+
+		$uid = $input->getOption('uid');
+		if ($uid === null || $uid === '') {
+			if ($this->config->useHashedEmailAsUserID()) {
+				$email = strtolower($email);
+				$uid = hash('sha256', $email);
+			} else {
+				$uid = $email;
+			}
 		}
 
 		// same behavior like in the UsersController

--- a/lib/Controller/UsersController.php
+++ b/lib/Controller/UsersController.php
@@ -286,6 +286,12 @@ class UsersController extends OCSController {
 			], Http::STATUS_CONFLICT);
 		}
 
+		if ($this->groupManager->isAdmin($userId) || $this->subAdmin->isSubAdmin($user)) {
+			return new DataResponse([
+				'message' => $this->l10n->t('Accounts with administrative privileges cannot be converted to guests')
+			], Http::STATUS_CONFLICT);
+		}
+
 		try {
 			$this->conversionService->convertToGuest($user, $author);
 			$this->guestManager->setGuestQuota($user);

--- a/lib/Controller/UsersController.php
+++ b/lib/Controller/UsersController.php
@@ -14,6 +14,7 @@ use OCA\Guests\Config;
 use OCA\Guests\Db\Transfer;
 use OCA\Guests\Db\TransferMapper;
 use OCA\Guests\GuestManager;
+use OCA\Guests\Service\ConversionService;
 use OCA\Guests\Service\InviteService;
 use OCA\Guests\TransferService;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -29,6 +30,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Mail\IMailer;
+use Psr\Log\LoggerInterface;
 
 class UsersController extends OCSController {
 	public function __construct(
@@ -45,6 +47,8 @@ class UsersController extends OCSController {
 		private readonly TransferService $transferService,
 		private readonly TransferMapper $transferMapper,
 		private readonly InviteService $inviteService,
+		private readonly ConversionService $conversionService,
+		private readonly LoggerInterface $logger,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -244,5 +248,54 @@ class UsersController extends OCSController {
 		$this->transferService->addTransferJob($author, $sourceUser, $targetUserId);
 
 		return new DataResponse([], Http::STATUS_CREATED);
+	}
+
+	/**
+	 * Convert a regular, never-logged-in account into a guest account
+	 */
+	public function convert(string $userId): DataResponse {
+		$author = $this->userSession->getUser();
+		if (!($author instanceof IUser)) {
+			return new DataResponse([
+				'message' => $this->l10n->t('Failed to authorize')
+			], Http::STATUS_UNAUTHORIZED);
+		}
+
+		$user = $this->userManager->get($userId);
+		if (!($user instanceof IUser)) {
+			return new DataResponse([
+				'message' => $this->l10n->t('Account not found')
+			], Http::STATUS_NOT_FOUND);
+		}
+
+		if ($this->guestManager->isGuest($user)) {
+			return new DataResponse([
+				'message' => $this->l10n->t('Account is already a guest')
+			], Http::STATUS_CONFLICT);
+		}
+
+		if ($user->getBackendClassName() !== 'Database') {
+			return new DataResponse([
+				'message' => $this->l10n->t('Only regular accounts can be converted to guests')
+			], Http::STATUS_CONFLICT);
+		}
+
+		if ($user->getLastLogin() !== 0) {
+			return new DataResponse([
+				'message' => $this->l10n->t('Only accounts that have never logged in can be converted')
+			], Http::STATUS_CONFLICT);
+		}
+
+		try {
+			$this->conversionService->convertToGuest($user, $author);
+			$this->guestManager->setGuestQuota($user);
+		} catch (\Throwable $e) {
+			$this->logger->error('Failed to convert account "' . $userId . '" to a guest', ['exception' => $e]);
+			return new DataResponse([
+				'message' => $this->l10n->t('An error occurred while converting the account')
+			], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+
+		return new DataResponse([]);
 	}
 }

--- a/lib/GuestManager.php
+++ b/lib/GuestManager.php
@@ -111,9 +111,16 @@ class GuestManager {
 			);
 		}
 
-		$user->setQuota($this->appConfig->getAppValueString(ConfigLexicon::GUEST_DISK_QUOTA));
+		$this->setGuestQuota($user);
 
 		return $user;
+	}
+
+	/**
+	 * Apply the configured default guest quota to an account.
+	 */
+	public function setGuestQuota(IUser $user): void {
+		$user->setQuota($this->appConfig->getAppValueString(ConfigLexicon::GUEST_DISK_QUOTA));
 	}
 
 	/**

--- a/lib/Service/ConversionService.php
+++ b/lib/Service/ConversionService.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Guests\Service;
+
+use OCA\Guests\AppInfo\Application;
+use OCA\Guests\ConfigLexicon;
+use OCP\Config\IUserConfig;
+use OCP\IDBConnection;
+use OCP\IUser;
+
+/**
+ * Converts a regular account into a guest account by moving it from the core
+ * "Database" user backend into the guests backend.
+ *
+ * The user ID is preserved, so all existing account data, home storage and
+ * mounts stay valid, and the password hash is carried over unchanged. The
+ * caller is responsible for checking eligibility (database backend, never
+ * logged in, not already a guest).
+ */
+class ConversionService {
+	public function __construct(
+		private readonly IDBConnection $connection,
+		private readonly IUserConfig $userConfig,
+	) {
+	}
+
+	public function convertToGuest(IUser $user, IUser $createdBy): void {
+		$uid = $user->getUID();
+		$uidLower = mb_strtolower($uid);
+		$displayName = $user->getDisplayName();
+		$email = $user->getSystemEMailAddress() ?? '';
+
+		// Carry over the existing password hash from the database backend.
+		$query = $this->connection->getQueryBuilder();
+		$query->select('password')
+			->from('users')
+			->where($query->expr()->eq('uid_lower', $query->createNamedParameter($uidLower)));
+		$result = $query->executeQuery();
+		$passwordHash = $result->fetchOne();
+		$result->closeCursor();
+		if ($passwordHash === false) {
+			throw new \RuntimeException('No password hash found for "' . $uid . '"');
+		}
+
+		// Move the account between backends in a single transaction. The user ID
+		// is unchanged, so all data keyed by it (account, home storage, mounts,
+		// shares) stays valid.
+		$this->connection->beginTransaction();
+		try {
+			$insert = $this->connection->getQueryBuilder();
+			$insert->insert('guests_users')
+				->values([
+					'uid' => $insert->createNamedParameter($uid),
+					'uid_lower' => $insert->createNamedParameter($uidLower),
+					'displayname' => $insert->createNamedParameter($displayName),
+					'password' => $insert->createNamedParameter($passwordHash),
+					'email' => $insert->createNamedParameter($email),
+				]);
+			$insert->executeStatement();
+
+			$delete = $this->connection->getQueryBuilder();
+			$delete->delete('users')
+				->where($delete->expr()->eq('uid_lower', $delete->createNamedParameter($uidLower)));
+			$delete->executeStatement();
+
+			$this->connection->commit();
+		} catch (\Throwable $e) {
+			$this->connection->rollBack();
+			throw $e;
+		}
+
+		$this->userConfig->setValueString($uid, Application::APP_ID, ConfigLexicon::USER_CREATED_BY, $createdBy->getUID());
+	}
+}

--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -330,8 +330,7 @@ class UserBackend extends ABackend implements
 			return false;
 		}
 
-		// guests $uid could be NULL or ''
-		// or is not an email anyway
+		// Skip empty IDs; any non-empty ID is resolved against the guests_users table.
 		if (!$this->potentialGuestUserId($uid)) {
 			$this->cache[$uid] = false;
 			return false;
@@ -473,14 +472,10 @@ class UserBackend extends ABackend implements
 	}
 
 	/**
-	 * Guest app user ids are:
-	 * - either email addresses so they need to contain an @
-	 * - lowercase sha256 hashes of email addresses, 64 characters of a-f and 0-9
-	 *
-	 * @param string $userId
-	 * @return bool
+	 * Guard against empty IDs only. Any non-empty ID may belong to a guest and is
+	 * resolved against the guests_users table.
 	 */
 	protected function potentialGuestUserId(string $userId): bool {
-		return str_contains($userId, '@') || preg_match('/^[a-f0-9]{64}$/', $userId);
+		return $userId !== '';
 	}
 }

--- a/src/components/ConvertToGuestDialog.vue
+++ b/src/components/ConvertToGuestDialog.vue
@@ -1,0 +1,109 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<NcDialog
+		:name="t('guests', 'Convert to guest account')"
+		:outTransition="true"
+		size="small"
+		@closing="cancel">
+		<NcNoteCard type="warning">
+			{{ t('guests', 'The account "{userId}" will be converted into a guest account. It keeps its login name and password but becomes a limited guest account, restricted to the apps allowed for guests.', { userId: String(user.id) }) }}
+		</NcNoteCard>
+		<p class="convert-dialog__hint">
+			{{ t('guests', 'This is only possible for accounts that have never logged in. It cannot be undone automatically.') }}
+		</p>
+
+		<template #actions>
+			<NcButton
+				variant="tertiary"
+				:disabled="loading"
+				@click="cancel">
+				{{ t('guests', 'Cancel') }}
+			</NcButton>
+
+			<NcButton
+				variant="error"
+				:disabled="loading"
+				@click="submit">
+				<template v-if="loading" #icon>
+					<NcLoadingIcon :name="t('guests', 'Converting account…')" />
+				</template>
+				{{ t('guests', 'Convert to guest') }}
+			</NcButton>
+		</template>
+	</NcDialog>
+</template>
+
+<script lang="ts">
+import type { PropType } from 'vue'
+import type { User } from '../types.ts'
+
+import axios from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
+import { translate as t } from '@nextcloud/l10n'
+import { generateOcsUrl } from '@nextcloud/router'
+import { defineComponent } from 'vue'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcDialog from '@nextcloud/vue/components/NcDialog'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+import { logger } from '../services/logger.ts'
+
+export default defineComponent({
+	name: 'ConvertToGuestDialog',
+
+	components: {
+		NcButton,
+		NcDialog,
+		NcLoadingIcon,
+		NcNoteCard,
+	},
+
+	props: {
+		user: {
+			type: Object as PropType<User>,
+			default: () => ({}),
+		},
+	},
+
+	emits: ['close'],
+
+	data() {
+		return {
+			loading: false,
+		}
+	},
+
+	methods: {
+		t,
+
+		async submit(): Promise<void> {
+			this.loading = true
+			const userId = String(this.user.id)
+			try {
+				await axios.post(generateOcsUrl('/apps/guests/api/v1/convert'), { userId })
+				this.$emit('close', userId)
+			} catch (error: unknown) {
+				const message = (error as { response?: { data?: { ocs?: { data?: { message?: string } } } } })
+					?.response?.data?.ocs?.data?.message
+				logger.error(message ?? 'Failed to convert account to guest', { error })
+				showError(message ?? t('guests', 'An error occurred while converting the account'))
+				this.$emit('close', null)
+			}
+			this.loading = false
+		},
+
+		cancel(): void {
+			this.$emit('close', null)
+		},
+	},
+})
+</script>
+
+<style lang="scss" scoped>
+.convert-dialog__hint {
+	margin-top: 8px;
+}
+</style>

--- a/src/users.ts
+++ b/src/users.ts
@@ -5,11 +5,13 @@
 
 import type { User } from './types.ts'
 
+import SvgAccountArrowLeft from '@mdi/svg/svg/account-arrow-left.svg?raw'
 import SvgAccountArrowRight from '@mdi/svg/svg/account-arrow-right.svg?raw'
 import { showSuccess } from '@nextcloud/dialogs'
 import { subscribe } from '@nextcloud/event-bus'
 import { translate as t } from '@nextcloud/l10n'
 import { spawnDialog } from '@nextcloud/vue/functions/dialog'
+import ConvertToGuestDialog from './components/ConvertToGuestDialog.vue'
 import TransferGuestDialog from './components/TransferGuestDialog.vue'
 
 /**
@@ -31,7 +33,28 @@ function transferGuest(_event: MouseEvent, user: User): void {
 	}, onClose)
 }
 
-const enabled = (user: User) => user?.backend === 'Guests'
+/**
+ *
+ * @param _event unused click event
+ * @param user the account from the user-management list
+ */
+function convertToGuest(_event: MouseEvent, user: User): void {
+	const onClose = (userId: null | string) => {
+		if (userId === null) {
+			return
+		}
+		showSuccess(t('guests', 'Account "{userId}" was converted into a guest account', { userId }))
+		window.location.reload()
+	}
+
+	spawnDialog(ConvertToGuestDialog, {
+		user,
+		// @ts-expect-error callback parameters are known
+	}, onClose)
+}
+
+const isGuest = (user: User) => user?.backend === 'Guests'
+const isConvertibleAccount = (user: User) => user?.backend === 'Database' && !user?.lastLogin
 
 /**
  *
@@ -41,7 +64,13 @@ function registerAction() {
 		SvgAccountArrowRight,
 		t('guests', 'Convert guest to regular account'),
 		transferGuest,
-		enabled,
+		isGuest,
+	)
+	window.OCA.Settings.UserList.registerAction(
+		SvgAccountArrowLeft,
+		t('guests', 'Convert to guest account'),
+		convertToGuest,
+		isConvertibleAccount,
 	)
 }
 

--- a/tests/unit/Command/AddCommandTest.php
+++ b/tests/unit/Command/AddCommandTest.php
@@ -186,4 +186,49 @@ class AddCommandTest extends TestCase {
 		$this->assertStringContainsString('Invalid email address "guestid@@@".', $output);
 		$this->assertEquals(1, $this->commandTester->getStatusCode());
 	}
+
+	public function testCreateGuestWithCustomUid(): void {
+		$createdByUser = $this->createStub(IUser::class);
+
+		$guestUser = $this->createMock(IUser::class);
+		$guestUser->method('getUID')->willReturn('karl');
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with('creator')
+			->willReturn($createdByUser);
+
+		// The explicit login name is used as the user ID, not the email or its hash.
+		$this->userManager->expects($this->once())
+			->method('userExists')
+			->with('karl')
+			->willReturn(false);
+
+		$this->mailer->expects($this->once())
+			->method('validateMailAddress')
+			->with('guestid@example.com')
+			->willReturn(true);
+
+		$this->guestManager->expects($this->once())
+			->method('createGuest')
+			->with(
+				$createdByUser,
+				'karl',
+				'guestid@example.com',
+				'',
+				'',
+				null
+			)
+			->willReturn($guestUser);
+
+		$this->commandTester->execute([
+			'created-by' => 'creator',
+			'email' => 'guestid@example.com',
+			'--uid' => 'karl',
+			'--generate-password' => true,
+		]);
+
+		$output = $this->commandTester->getDisplay();
+		$this->assertStringContainsString('The guest account user "karl" was created successfully', $output);
+	}
 }

--- a/tests/unit/Controller/UsersControllerTest.php
+++ b/tests/unit/Controller/UsersControllerTest.php
@@ -13,6 +13,7 @@ use OCA\Guests\Config;
 use OCA\Guests\Controller\UsersController;
 use OCA\Guests\Db\TransferMapper;
 use OCA\Guests\GuestManager;
+use OCA\Guests\Service\ConversionService;
 use OCA\Guests\Service\InviteService;
 use OCA\Guests\TransferService;
 use OCP\AppFramework\Http;
@@ -29,6 +30,7 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Mail\IMailer;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class UsersControllerTest extends TestCase {
@@ -46,6 +48,8 @@ class UsersControllerTest extends TestCase {
 	private IAppConfig&MockObject $appConfig;
 	private IConfig&MockObject $config;
 	private InviteService&MockObject $inviteService;
+	private ConversionService&MockObject $conversionService;
+	private LoggerInterface&MockObject $logger;
 	private Config $guestsConfig;
 
 	private UsersController $controller;
@@ -67,6 +71,8 @@ class UsersControllerTest extends TestCase {
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->inviteService = $this->createMock(InviteService::class);
+		$this->conversionService = $this->createMock(ConversionService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->guestsConfig = new Config(
 			$this->config,
@@ -93,7 +99,9 @@ class UsersControllerTest extends TestCase {
 			$this->groupManager,
 			$this->transferService,
 			$this->transferMapper,
-			$this->inviteService
+			$this->inviteService,
+			$this->conversionService,
+			$this->logger
 		);
 	}
 
@@ -751,5 +759,63 @@ class UsersControllerTest extends TestCase {
 		$response = $this->controller->create('new@example.com', 'Test User', 'en', []);
 		$this->assertEquals(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
 		$this->assertEquals(['errorMessages' => ['email' => 'Error creating guest']], $response->getData());
+	}
+
+	public function testConvertSucceeds(): void {
+		$author = $this->createMock(IUser::class);
+		$this->userSession->method('getUser')->willReturn($author);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getBackendClassName')->willReturn('Database');
+		$user->method('getLastLogin')->willReturn(0);
+
+		$this->userManager->method('get')->with('karl')->willReturn($user);
+		$this->guestManager->method('isGuest')->with($user)->willReturn(false);
+
+		$this->conversionService->expects($this->once())
+			->method('convertToGuest')
+			->with($user, $author);
+
+		$this->guestManager->expects($this->once())
+			->method('setGuestQuota')
+			->with($user);
+
+		$response = $this->controller->convert('karl');
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+	}
+
+	public function testConvertAccountNotFound(): void {
+		$this->userSession->method('getUser')->willReturn($this->createMock(IUser::class));
+		$this->userManager->method('get')->with('karl')->willReturn(null);
+
+		$response = $this->controller->convert('karl');
+		$this->assertEquals(Http::STATUS_NOT_FOUND, $response->getStatus());
+	}
+
+	public function testConvertAlreadyGuest(): void {
+		$this->userSession->method('getUser')->willReturn($this->createMock(IUser::class));
+
+		$user = $this->createMock(IUser::class);
+		$this->userManager->method('get')->with('karl')->willReturn($user);
+		$this->guestManager->method('isGuest')->with($user)->willReturn(true);
+
+		$response = $this->controller->convert('karl');
+		$this->assertEquals(Http::STATUS_CONFLICT, $response->getStatus());
+	}
+
+	public function testConvertRejectsAccountThatLoggedIn(): void {
+		$this->userSession->method('getUser')->willReturn($this->createMock(IUser::class));
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getBackendClassName')->willReturn('Database');
+		$user->method('getLastLogin')->willReturn(1700000000);
+
+		$this->userManager->method('get')->with('karl')->willReturn($user);
+		$this->guestManager->method('isGuest')->with($user)->willReturn(false);
+
+		$this->conversionService->expects($this->never())->method('convertToGuest');
+
+		$response = $this->controller->convert('karl');
+		$this->assertEquals(Http::STATUS_CONFLICT, $response->getStatus());
 	}
 }

--- a/tests/unit/Controller/UsersControllerTest.php
+++ b/tests/unit/Controller/UsersControllerTest.php
@@ -803,6 +803,41 @@ class UsersControllerTest extends TestCase {
 		$this->assertEquals(Http::STATUS_CONFLICT, $response->getStatus());
 	}
 
+	public function testConvertRejectsAdmin(): void {
+		$this->userSession->method('getUser')->willReturn($this->createMock(IUser::class));
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getBackendClassName')->willReturn('Database');
+		$user->method('getLastLogin')->willReturn(0);
+
+		$this->userManager->method('get')->with('karl')->willReturn($user);
+		$this->guestManager->method('isGuest')->with($user)->willReturn(false);
+		$this->groupManager->method('isAdmin')->with('karl')->willReturn(true);
+
+		$this->conversionService->expects($this->never())->method('convertToGuest');
+
+		$response = $this->controller->convert('karl');
+		$this->assertEquals(Http::STATUS_CONFLICT, $response->getStatus());
+	}
+
+	public function testConvertRejectsSubAdmin(): void {
+		$this->userSession->method('getUser')->willReturn($this->createMock(IUser::class));
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getBackendClassName')->willReturn('Database');
+		$user->method('getLastLogin')->willReturn(0);
+
+		$this->userManager->method('get')->with('karl')->willReturn($user);
+		$this->guestManager->method('isGuest')->with($user)->willReturn(false);
+		$this->groupManager->method('isAdmin')->with('karl')->willReturn(false);
+		$this->subAdmin->method('isSubAdmin')->with($user)->willReturn(true);
+
+		$this->conversionService->expects($this->never())->method('convertToGuest');
+
+		$response = $this->controller->convert('karl');
+		$this->assertEquals(Http::STATUS_CONFLICT, $response->getStatus());
+	}
+
 	public function testConvertRejectsAccountThatLoggedIn(): void {
 		$this->userSession->method('getUser')->willReturn($this->createMock(IUser::class));
 

--- a/tests/unit/Service/ConversionServiceTest.php
+++ b/tests/unit/Service/ConversionServiceTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Guests\Test\Unit\Service;
+
+use OCA\Guests\AppInfo\Application;
+use OCA\Guests\ConfigLexicon;
+use OCA\Guests\Service\ConversionService;
+use OCP\Config\IUserConfig;
+use OCP\IDBConnection;
+use OCP\IUser;
+use OCP\Server;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class ConversionServiceTest extends TestCase {
+	private IDBConnection $db;
+	private IUserConfig&MockObject $userConfig;
+	private ConversionService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->db = Server::get(IDBConnection::class);
+		$this->cleanup();
+		$this->userConfig = $this->createMock(IUserConfig::class);
+		$this->service = new ConversionService($this->db, $this->userConfig);
+	}
+
+	protected function tearDown(): void {
+		$this->cleanup();
+		parent::tearDown();
+	}
+
+	private function cleanup(): void {
+		foreach (['guests_users', 'users'] as $table) {
+			$query = $this->db->getQueryBuilder();
+			$query->delete($table)
+				->where($query->expr()->eq('uid_lower', $query->createNamedParameter('karl')));
+			$query->executeStatement();
+		}
+	}
+
+	private function rowExists(string $table): bool {
+		$query = $this->db->getQueryBuilder();
+		$query->select('uid')
+			->from($table)
+			->where($query->expr()->eq('uid_lower', $query->createNamedParameter('karl')));
+		$result = $query->executeQuery();
+		$uid = $result->fetchOne();
+		$result->closeCursor();
+		return $uid !== false;
+	}
+
+	public function testConvertToGuest(): void {
+		// Seed a regular (database backend) account.
+		$insert = $this->db->getQueryBuilder();
+		$insert->insert('users')
+			->values([
+				'uid' => $insert->createNamedParameter('karl'),
+				'uid_lower' => $insert->createNamedParameter('karl'),
+				'displayname' => $insert->createNamedParameter('Karl Doe'),
+				'password' => $insert->createNamedParameter('3|$argon2id$v=19$dummyhash'),
+			]);
+		$insert->executeStatement();
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('karl');
+		$user->method('getDisplayName')->willReturn('Karl Doe');
+		$user->method('getSystemEMailAddress')->willReturn('karl.doe@example.tld');
+
+		$createdBy = $this->createMock(IUser::class);
+		$createdBy->method('getUID')->willReturn('admin');
+
+		$this->userConfig->expects($this->once())
+			->method('setValueString')
+			->with('karl', Application::APP_ID, ConfigLexicon::USER_CREATED_BY, 'admin');
+
+		$this->service->convertToGuest($user, $createdBy);
+
+		// The account moved from the database backend to the guests backend,
+		// keeping its user ID, display name and password hash.
+		$this->assertFalse($this->rowExists('users'));
+		$this->assertTrue($this->rowExists('guests_users'));
+
+		$query = $this->db->getQueryBuilder();
+		$query->select('password', 'email', 'displayname')
+			->from('guests_users')
+			->where($query->expr()->eq('uid_lower', $query->createNamedParameter('karl')));
+		$result = $query->executeQuery();
+		$row = $result->fetch();
+		$result->closeCursor();
+
+		$this->assertIsArray($row);
+		$this->assertSame('3|$argon2id$v=19$dummyhash', $row['password']);
+		$this->assertSame('karl.doe@example.tld', $row['email']);
+		$this->assertSame('Karl Doe', $row['displayname']);
+	}
+}

--- a/tests/unit/UserBackendTest.php
+++ b/tests/unit/UserBackendTest.php
@@ -87,4 +87,19 @@ class UserBackendTest extends TestCase {
 		$this->assertEquals(['foo'], array_values($this->backend->getDisplayNames($email)));
 		$this->assertEquals(['foo'], array_values($this->backend->getDisplayNames(substr($email, 0, 10))));
 	}
+
+	public function testCustomLoginNameUid(): void {
+		// A free-form UID (neither an email nor a sha256 hash) must be recognised.
+		$uid = 'karl';
+		$email = 'karl.doe@example.tld';
+		$this->backend->createUser($uid, 'bar');
+		$this->backend->setInitialEmail($uid, $email);
+		$this->backend->setDisplayName($uid, 'Karl Doe');
+
+		$this->assertTrue($this->backend->userExists($uid));
+		$this->assertEquals($uid, $this->backend->getRealUID($uid));
+		$this->assertEquals($uid, $this->backend->checkPassword($uid, 'bar'));
+		$this->assertEquals($uid, $this->backend->checkPassword($email, 'bar'));
+		$this->assertEquals('Karl Doe', $this->backend->getDisplayName($uid));
+	}
 }


### PR DESCRIPTION
### Summary

Adds an admin action to convert a regular account into a guest account, and lets guests have a free-form login name instead of one derived from their email.

Closes #1153
Closes #333
Related #1479

## Convert accounts to guests

Create a user (just for testing):

```bash
$ NC_PASS=karltest occ user:add --password-from-env --display-name="Karl Test" -- karltest
The account "karltest" was created successfully
Display name set to "Karl Test"
```

```bash
$ occ user:info karltest
  - user_id: karltest
  - display_name: Karl Test
  - email:
  - cloud_id: karltest@global-social.net
  - enabled: true
  - groups:
  - quota: none
  - storage:
    - free: 1184627609600
    - used: 0
    - total: 1184627609600
    - relative: 0
    - quota: -3
  - first_seen: never
  - last_seen: never
  - user_directory: /nc/dat/data/karltest
  - backend: Database
```

In *Administration settings → Users*, the account's `…` menu gains **Convert to guest account**.

<img width="1996" height="283" alt="image" src="https://github.com/user-attachments/assets/18f23b2b-2739-4a2c-9e90-fd72d784754c" />

A confirmation dialog explains the effect: the account keeps its login name and password but becomes a limited guest, restricted to the apps allowed for guests, and receives the default guest quota. The conversion cannot be undone automatically.

<img width="458" height="331" alt="image" src="https://github.com/user-attachments/assets/be811c06-a9f3-4fb7-b15d-2ed1626c6281" />

It is only possible for accounts that use the database backend, are not already a guest, and have **never logged in** (enforced in the UI and in the OCS endpoint).

After conversion the account's backend is **Guests**:

<img width="1997" height="86" alt="image" src="https://github.com/user-attachments/assets/c2d5dad2-6af8-4751-8e6e-dd56017c1238" />

and it logs in with the same password:

<img width="1440" height="857" alt="image" src="https://github.com/user-attachments/assets/aa35d59b-cba8-4923-9a16-e7d88074760b" />

It then appears in the guests list:

<img width="1430" height="890" alt="image" src="https://github.com/user-attachments/assets/dfc37c5c-9763-415f-a02c-f264f02cab6f" />

### Use case: self-registration

A typical use case is self-registration through the [registration](https://apps.nextcloud.com/apps/registration) app with *"Require administrator approval"* enabled: those accounts are created disabled and never logged in, so an administrator can downgrade them to guests instead of enabling them. Once such an account has logged in, conversion is no longer possible.

If you would rather registered users keep their email address as login name, enable *"Force email as login name"* in the registration app settings.

## Custom guest login names

`occ guests:add` gains `--uid` to set a free-form login name, instead of always deriving the user ID from the email address (or its hash):

```bash
$ occ guests:add --help
Description:
  Add a new guest account

Usage:
  guests:add [options] [--] <created-by> <email>

Arguments:
  created-by                         User ID who is set as creator
  email                              Email address

Options:
      --uid=UID                      Login name (user ID) for the guest. If omitted, the email address is used (hashed when the privacy setting is enabled).
      --generate-password            Do not set an initial password
      --password-from-env            Read password from environment variable OC_PASS
      --display-name[=DISPLAY-NAME]  User name used in the web UI (can contain any characters) [default: ""]
      --language[=LANGUAGE]          Language [default: ""]
  -h, --help                         Display help for the given command. When no command is given display help for the list command
  -q, --quiet                        Do not output any message
  -V, --version                      Display this application version
      --ansi|--no-ansi               Force (or disable --no-ansi) ANSI output
  -n, --no-interaction               Do not ask any interactive question
      --no-warnings                  Skip global warnings, show command output only
  -v|vv|vvv, --verbose               Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

Example — create a guest with a chosen login name and verify the user ID:

```
$ occ guests:add admin guest@example.com --uid=freddy
$ occ user:info freddy
```

The guests backend user-id guard is loosened accordingly to accept any non-empty id.

## Implementation

- `ConversionService` performs the transactional `users` → `guests_users` move (uid, display name, password hash and email preserved).
- `UsersController::convert()` OCS endpoint (admin-only) with the eligibility checks above; route `POST /api/v1/convert`.
- `GuestManager::setGuestQuota()` extracted so both newly created and converted guests get the configured default quota.
- `occ guests:add --uid` for a free-form login name.
- Unit tests for the backend guard, the `--uid` option, the controller endpoint and the conversion service.

## Testing

Verified on a live instance (screenshots above): created a never-logged-in database account, converted it via the UI, confirmed the backend switched to Guests, the account logs in with the same password, and it appears in the guests list. The action is hidden for accounts that have logged in and for existing guests.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI
Assisted-by: ClaudeCode:claude-opus-4-8

