### PR TITLE
fix(tests): scope admin settings heading locator to the guests section

### DIFF
--- a/playwright/e2e/admin-settings.spec.ts
+++ b/playwright/e2e/admin-settings.spec.ts
@@ -13,7 +13,8 @@ test('Admin Guests settings page renders without errors', async ({ adminPage }) 
 
 	await adminPage.goto('/settings/admin/guests')
 
-	await expect(adminPage.getByRole('heading', { name: 'Guests', exact: true })).toBeVisible()
+	// Scope to our section: the framework also renders a hidden page <h1> with the section name.
+	await expect(adminPage.locator('#guest-settings').getByRole('heading', { name: 'Guests', exact: true })).toBeVisible()
 	await expect(adminPage.getByRole('checkbox', { name: /external storage/i })).toBeVisible()
 
 	expect(pageErrors, `uncaught page errors: ${pageErrors.join(' | ')}`).toEqual([])


### PR DESCRIPTION
The `test` (Playwright) job has been red on `main` and on every PR since around 2026-06-11. It is not caused by any guests change: between the last green run (2026-06-09) and the first red one (2026-06-11) the only commits were a Transifex l10n update and an AUTHORS entry, and `admin-settings.spec.ts` itself is unchanged since it was added.

The assertion trips Playwright strict mode:

```
getByRole('heading', { name: 'Guests', exact: true }) resolved to 2 elements:
  1) <h1 class="hidden-visually" id="page-heading-level-1">Guests</h1>
  2) <h2 class="settings-section__name">Guests</h2>  (inside #guest-settings)
```

The settings framework renders a visually-hidden page heading `<h1>` carrying the active section name ("Guests"), which collides with our own section `<h2>`. That `<h1>` is server-side and predates this app; nothing in this repo changed. The `test` job boots the `continuous-integration-shallow-server` image, a shallow clone of `nextcloud/server` master taken [at image build time](https://github.com/nextcloud/docker-ci/blob/9e17ac5c180031ea08b58aae6587cdaa6392205e/shallow-server/Dockerfile#L37) in `nextcloud/docker-ci`; it was last rebuilt on 2026-06-10 ([build](https://github.com/nextcloud/docker-ci/actions/runs/27303325361)) and the first guests run afterwards is the first red one: [green 2026-06-09](https://github.com/nextcloud/guests/actions/runs/27195091394) → [red 2026-06-11](https://github.com/nextcloud/guests/actions/runs/27316897078), red on every run since.

This scopes the locator to the app's `#guest-settings` container, which is exactly what Playwright's own error output suggests, so it matches only our section heading. No change to app behaviour.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
Assisted-by: ClaudeCode:claude-opus-4-8