### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/vendor-bin/nextcloud-ocp/composer.lock
+++ b/vendor-bin/nextcloud-ocp/composer.lock
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "0f3bbf18846c7bf9e8dea4da2bf045be24be61eb"
+                "reference": "0cfbb31da7a049c20d512745d622bb617bc5777b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/0f3bbf18846c7bf9e8dea4da2bf045be24be61eb",
-                "reference": "0f3bbf18846c7bf9e8dea4da2bf045be24be61eb",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/0cfbb31da7a049c20d512745d622bb617bc5777b",
+                "reference": "0cfbb31da7a049c20d512745d622bb617bc5777b",
                 "shasum": ""
             },
             "require": {
@@ -53,7 +53,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable32"
             },
-            "time": "2026-07-16T01:28:14+00:00"
+            "time": "2026-08-05T01:28:07+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency