### PR TITLE
fix(restrictions): Apply the app config overwrite to the typed getters

### DIFF
--- a/lib/AppConfigOverwrite.php
+++ b/lib/AppConfigOverwrite.php
@@ -30,4 +30,22 @@ class AppConfigOverwrite extends AppConfig {
 
 		return parent::getValue($app, $key, $default);
 	}
+
+	#[\Override]
+	public function getValueString(string $app, string $key, string $default = '', bool $lazy = false): string {
+		if (isset($this->overWrite[$app]) && isset($this->overWrite[$app][$key])) {
+			return $this->overWrite[$app][$key];
+		}
+
+		return parent::getValueString($app, $key, $default, $lazy);
+	}
+
+	#[\Override]
+	public function getValueBool(string $app, string $key, bool $default = false, bool $lazy = false): bool {
+		if (isset($this->overWrite[$app]) && isset($this->overWrite[$app][$key])) {
+			return in_array(strtolower($this->overWrite[$app][$key]), ['1', 'true', 'yes', 'on'], true);
+		}
+
+		return parent::getValueBool($app, $key, $default, $lazy);
+	}
 }

--- a/lib/AppConfigOverwrite.php
+++ b/lib/AppConfigOverwrite.php
@@ -48,4 +48,32 @@ class AppConfigOverwrite extends AppConfig {
 
 		return parent::getValueBool($app, $key, $default, $lazy);
 	}
+
+	#[\Override]
+	public function getValueInt(string $app, string $key, int $default = 0, bool $lazy = false): int {
+		if (isset($this->overWrite[$app]) && isset($this->overWrite[$app][$key])) {
+			return (int)$this->overWrite[$app][$key];
+		}
+
+		return parent::getValueInt($app, $key, $default, $lazy);
+	}
+
+	#[\Override]
+	public function getValueFloat(string $app, string $key, float $default = 0, bool $lazy = false): float {
+		if (isset($this->overWrite[$app]) && isset($this->overWrite[$app][$key])) {
+			return (float)$this->overWrite[$app][$key];
+		}
+
+		return parent::getValueFloat($app, $key, $default, $lazy);
+	}
+
+	#[\Override]
+	public function getValueArray(string $app, string $key, array $default = [], bool $lazy = false): array {
+		if (isset($this->overWrite[$app]) && isset($this->overWrite[$app][$key])) {
+			$value = json_decode($this->overWrite[$app][$key], true);
+			return is_array($value) ? $value : $default;
+		}
+
+		return parent::getValueArray($app, $key, $default, $lazy);
+	}
 }

--- a/tests/stub.php
+++ b/tests/stub.php
@@ -139,6 +139,15 @@ namespace OC {
 
 		public function getValueBool(string $app, string $key, bool $default = false, bool $lazy = false): bool {
 		}
+
+		public function getValueInt(string $app, string $key, int $default = 0, bool $lazy = false): int {
+		}
+
+		public function getValueFloat(string $app, string $key, float $default = 0, bool $lazy = false): float {
+		}
+
+		public function getValueArray(string $app, string $key, array $default = [], bool $lazy = false): array {
+		}
 	}
 }
 

--- a/tests/stub.php
+++ b/tests/stub.php
@@ -133,6 +133,12 @@ namespace OC {
 		 */
 		public function getValue($app, $key, $default = '') {
 		}
+
+		public function getValueString(string $app, string $key, string $default = '', bool $lazy = false): string {
+		}
+
+		public function getValueBool(string $app, string $key, bool $default = false, bool $lazy = false): bool {
+		}
 	}
 }
 

--- a/tests/unit/AppConfigOverwriteTest.php
+++ b/tests/unit/AppConfigOverwriteTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Guests\Test\Unit;
+
+use OCA\Guests\AppConfigOverwrite;
+use OCP\Server;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class AppConfigOverwriteTest extends TestCase {
+	private const KEY = 'shareapi_only_share_with_group_members';
+
+	private ?AppConfigOverwrite $appConfig = null;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->appConfig = Server::get(AppConfigOverwrite::class);
+		$this->appConfig->setOverwrite(['core' => [self::KEY => 'yes']]);
+	}
+
+	protected function tearDown(): void {
+		$this->appConfig->setOverwrite([]);
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The server reads the overwritten values through several getters:
+	 * IConfig::getAppValue() ends up in getValue(), the share recipient
+	 * autocompletion uses getValueString() and OCA\Guests\Config uses
+	 * getValueBool(). All of them have to see the overwrite.
+	 */
+	public function testOverwriteIsAppliedToAllGetters(): void {
+		$this->assertSame('yes', $this->appConfig->getValue('core', self::KEY, 'no'));
+		$this->assertSame('yes', $this->appConfig->getValueString('core', self::KEY, 'no'));
+		$this->assertTrue($this->appConfig->getValueBool('core', self::KEY));
+	}
+
+	public function testWithoutOverwriteTheStoredValueIsUsed(): void {
+		$this->appConfig->setOverwrite([]);
+
+		$this->assertSame('no', $this->appConfig->getValue('core', self::KEY, 'no'));
+		$this->assertSame('no', $this->appConfig->getValueString('core', self::KEY, 'no'));
+		$this->assertFalse($this->appConfig->getValueBool('core', self::KEY));
+	}
+}


### PR DESCRIPTION
AppConfigOverwrite only overrode the deprecated getValue(). Server code has since moved to the typed getters, so the overwrite that lateSetupRestrictions() installs to force shareapi_only_share_with_group_members when "Hide other accounts from guests" is enabled was silently ignored by them.

Most notably OC\Collaboration\Collaborators\UserPlugin reads the option with getValueString(), so the share recipient autocompletion offered guests every account of the instance instead of only the members of their own groups. OCA\Guests\Config::isSharingRestrictedToGroup() reads it with getValueBool() and was equally unaffected by the overwrite.