### PR TITLE
fix(whitelisting): Make the blocked app message translatable again

### DIFF
--- a/lib/AppWhitelist.php
+++ b/lib/AppWhitelist.php
@@ -83,7 +83,8 @@ class AppWhitelist {
 		if (!$this->isUrlAllowed($user, $url)) {
 			header('HTTP/1.0 403 Forbidden');
 			Template::printErrorPage($this->l10n->t(
-				"Access to this resource ($app) is forbidden for guests."
+				'Access to this resource (%s) is forbidden for guests.',
+				[$app]
 			));
 			exit;
 		}


### PR DESCRIPTION
The app id was interpolated into the string handed to IL10N::t(), so the lookup key differed for every blocked app and matched no entry in any catalogue. The message was therefore always shown in English, and the string extraction never picked it up either.

Pass the app id as a translation parameter instead.