### PR TITLE
fix(backend): Upgrade outdated password hashes on email logins

### DIFF
--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -310,7 +310,9 @@ class UserBackend extends ABackend implements
 			$newHash = '';
 			if ($this->hasher->verify($password, $storedHash, $newHash)) {
 				if ($newHash !== '') {
-					$this->setPassword($loginName, $password);
+					// $loginName can be the email address, while setPassword()
+					// matches on the user id.
+					$this->setPassword((string)$row['uid'], $password);
 				}
 
 				return (string)$row['uid'];

--- a/tests/unit/UserBackendTest.php
+++ b/tests/unit/UserBackendTest.php
@@ -102,4 +102,28 @@ class UserBackendTest extends TestCase {
 		$this->assertEquals($uid, $this->backend->checkPassword($email, 'bar'));
 		$this->assertEquals('Karl Doe', $this->backend->getDisplayName($uid));
 	}
+
+	/**
+	 * An outdated hash has to be upgraded no matter whether the guest logged
+	 * in with the user id or with the email address.
+	 */
+	public function testOutdatedPasswordHashIsUpgradedOnEmailLogin(): void {
+		$email = 'foo@example.tld';
+		$uid = hash('sha256', $email);
+		$this->backend->createUser($uid, 'bar');
+		$this->backend->setInitialEmail($uid, $email);
+
+		// An unprefixed bcrypt hash is a legacy hash, so verifying it always
+		// hands back a replacement hash.
+		$legacyHash = password_hash('bar', PASSWORD_BCRYPT);
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
+		$query->update('guests_users')
+			->set('password', $query->createNamedParameter($legacyHash))
+			->where($query->expr()->eq('uid_lower', $query->createNamedParameter($uid)));
+		$query->executeStatement();
+
+		$this->assertEquals($uid, $this->backend->checkPassword($email, 'bar'));
+
+		$this->assertNotEquals($legacyHash, $this->backend->getPasswordHash($uid));
+	}
 }


### PR DESCRIPTION
checkPassword() accepts the user id or the email address, but handed the login name straight to setPassword(), which matches on uid_lower. When a guest with a hashed user id logged in with their email address the update therefore matched no row and the outdated hash stayed in place, so it was re-computed and dropped on every single login.

Use the user id that the lookup already returned.