### PR TITLE
fix(backend): Keep the display name ordering when searching guests

### DIFF
--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -233,7 +233,7 @@ class UserBackend extends ABackend implements
 				->orWhere($query->expr()->iLike('displayname', $query->createPositionalParameter('%' . $this->dbConn->escapeLikeParameter($search) . '%')))
 				->orWhere($query->expr()->iLike('configvalue', $query->createPositionalParameter('%' . $this->dbConn->escapeLikeParameter($search) . '%')))
 				->orderBy($query->func()->lower('displayname'), 'ASC')
-				->orderBy('uid_lower', 'ASC')
+				->addOrderBy('uid_lower', 'ASC')
 				->setMaxResults($limit)
 				->setFirstResult($offset);
 		}

--- a/tests/unit/UserBackendTest.php
+++ b/tests/unit/UserBackendTest.php
@@ -126,4 +126,17 @@ class UserBackendTest extends TestCase {
 
 		$this->assertNotEquals($legacyHash, $this->backend->getPasswordHash($uid));
 	}
+
+	/**
+	 * Searching orders by display name first, which also decides which
+	 * guests a limited search returns.
+	 */
+	public function testSearchIsOrderedByDisplayName(): void {
+		$this->backend->createUser('aaa@example.tld', 'bar');
+		$this->backend->setDisplayName('aaa@example.tld', 'Zoe');
+		$this->backend->createUser('zzz@example.tld', 'bar');
+		$this->backend->setDisplayName('zzz@example.tld', 'Alice');
+
+		$this->assertEquals(['Alice', 'Zoe'], array_values($this->backend->getDisplayNames('example.tld')));
+	}
 }


### PR DESCRIPTION
orderBy() replaces the order-by clause instead of appending to it, so the second call dropped the display name ordering and left the results sorted by user id only. With hashed user ids that ordering is effectively random, and it also decides which guests a limited search returns.