### PR TITLE
fix(settings): Load guest details by user id instead of email

### DIFF
--- a/src/components/GuestList.vue
+++ b/src/components/GuestList.vue
@@ -59,7 +59,7 @@
 							:key="guest.email + '-details'"
 							class="details">
 							<td colspan="5">
-								<GuestDetails :guestId="guest.email" />
+								<GuestDetails :guestId="guest.uid" />
 							</td>
 						</tr>
 					</template>


### PR DESCRIPTION
The guest list passed the email address to GuestDetails, which requests /apps/guests/api/v1/users/{userId}. That endpoint resolves shares by user id, and hashing the email into the user id is the default, so expanding a row showed an empty share list even though the "Received shares" column of the very same row reported shares.