### PR TITLE
fix: Remove uses of IServerContainer interface

### DIFF
--- a/lib/RestrictionManager.php
+++ b/lib/RestrictionManager.php
@@ -16,20 +16,18 @@ use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\Mount\IMountPoint;
 use OCP\INavigationManager;
 use OCP\IRequest;
-use OCP\IServerContainer;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Server;
 use OCP\Settings\IManager;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 class RestrictionManager {
-
 	public function __construct(
 		private readonly AppWhitelist $whitelist,
 		private readonly IRequest $request,
 		private readonly IUserSession $userSession,
-		private readonly IServerContainer $server,
 		private readonly GuestManager $guestManager,
 		private readonly IMountProviderCollection $mountProviderCollection,
 		private readonly Config $config,
@@ -66,29 +64,33 @@ class RestrictionManager {
 			if (!$this->config->allowExternalStorage()) {
 				$this->mountProviderCollection->registerMountFilter(fn (IMountPoint $mountPoint, IUser $user): bool => !($mountPoint instanceof ExternalMountPoint && $this->guestManager->isGuest($user)));
 			}
+			/** @var \OC\Server */
+			$server = Server::get(ContainerInterface::class);
 
 			/** @var NavigationManager $navManager */
-			$navManager = Server::get(INavigationManager::class);
+			$navManager = $server->get(INavigationManager::class);
 
-			$this->server->registerService(INavigationManager::class, fn (): FilteredNavigationManager => new FilteredNavigationManager($user, $navManager, $this->whitelist));
+			$server->registerService(INavigationManager::class, fn (): FilteredNavigationManager => new FilteredNavigationManager($user, $navManager, $this->whitelist));
 
-			$settingsManager = $this->server->get(IManager::class);
-			$this->server->registerService(IManager::class, fn (): FilteredSettingsManager => new FilteredSettingsManager($settingsManager, $this->whitelist));
+			$settingsManager = $server->get(IManager::class);
+			$server->registerService(IManager::class, fn (): FilteredSettingsManager => new FilteredSettingsManager($settingsManager, $this->whitelist));
 		}
 	}
 
 	public function lateSetupRestrictions(): void {
 		if ($this->guestManager->isGuest($this->userSession->getUser()) && $this->config->hideOtherUsers()) {
-			$this->server->get(\OCP\Contacts\IManager::class)->clear();
+			/** @var \OC\Server */
+			$server = Server::get(ContainerInterface::class);
+			$server->get(\OCP\Contacts\IManager::class)->clear();
 			$this->userBackend->setAllowListing(false);
 			/** @var AppConfigOverwrite $appConfig */
-			$appConfig = $this->server->get(AppConfigOverwrite::class);
+			$appConfig = $server->get(AppConfigOverwrite::class);
 			$appConfig->setOverwrite([
 				'core' => [
 					'shareapi_only_share_with_group_members' => 'yes'
 				]
 			]);
-			$this->server->registerService(AppConfig::class, fn () => $appConfig);
+			$server->registerService(AppConfig::class, fn () => $appConfig);
 		}
 	}
 }

--- a/tests/stub.php
+++ b/tests/stub.php
@@ -149,6 +149,21 @@ namespace OC {
 		public function getValueArray(string $app, string $key, array $default = [], bool $lazy = false): array {
 		}
 	}
+
+	class Server implements \Psr\Container\ContainerInterface {
+		/**
+		 * @param \Closure(\OCP\IContainer): mixed $closure
+		 */
+		public function registerService(string $name, Closure $closure, bool $shared = true): void {
+		}
+		/**
+		 * @template T
+		 * @param class-string<T>|string $id
+		 * @return ($id is class-string<T> ? T : mixed)
+		 */
+		public function get(string $id): mixed {
+		}
+	}
 }
 
 namespace OC\DB {
@@ -157,12 +172,9 @@ namespace OC\DB {
 }
 
 namespace {
-
-	use OCP\IServerContainer;
-
 	class OC {
 		public static $CLI = false;
-		/** @var IServerContainer */
+		/** @var \OC\Server */
 		public static $server;
 		public static $SERVERROOT = '';
 	}

--- a/tests/unit/RestrictionManagerTest.php
+++ b/tests/unit/RestrictionManagerTest.php
@@ -15,7 +15,6 @@ use OCA\Guests\RestrictionManager;
 use OCA\Guests\UserBackend;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\IRequest;
-use OCP\IServerContainer;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -42,7 +41,6 @@ class RestrictionManagerTest extends TestCase {
 			$this->whitelist,
 			$this->request,
 			$this->userSession,
-			$this->createMock(IServerContainer::class),
 			$this->createMock(GuestManager::class),
 			$this->createMock(IMountProviderCollection::class),
 			$this->createMock(Config::class),


### PR DESCRIPTION
This should help fix CI for https://github.com/nextcloud/server/pull/64095

As this application supports several server version I cannot use `\OC\Server` in DI as it was not registered before 36.
This application relies on internal methods to override services so the code cannot be extra-clean.

I decided to use `\OCP\Server::get(ContainerInterface::class)` to get the server object. `\OC::$server` would work too.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
